### PR TITLE
Simplify Signal type, introduce lawful Monoid instance for Signal

### DIFF
--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -9,7 +9,6 @@ module Syzygy where
 import Data.Profunctor
 import Data.Function ((&))
 import Data.Monoid
-import qualified Test.QuickCheck as QC
 
 type Time = Rational
 
@@ -20,32 +19,8 @@ data Event a = MkEvent
   , payload :: a
   } deriving (Eq, Show, Functor)
 
--- type SignalEvent a = Event (Event a)
--- data SignalEvent a = MkSignalEvent
---   { support :: Interval
---   , event :: Event a
---   } deriving (Eq, Show, Functor)
-
 newtype Signal a = MkSignal { signal :: Interval -> [Event a] } -- A signal is defined by the "integral" of a sampling function
 
-
--- instance Monoid Interval where
---   MkInterval startX endX `mappend` MkInterval startY endY =
---     let lengthX = endX - startX
---     in MkInterval (startX + lengthX * startY) (startX + lengthX * endY)
---   mempty = MkInterval 0 1
-
--- instance Applicative Event where
---   pure x = MkEvent { query = MkInterval 0 1, payload = x}
-
---   MkEvent {query = queryF, payload = f} <*> MkEvent {query = queryX, payload = x} =
---     MkEvent { query = queryF <> queryX, payload = f x }
-
-instance QC.Arbitrary a => QC.Arbitrary (Event a) where
-  arbitrary = do
-    query <- QC.arbitrary
-    payload <- QC.arbitrary
-    return MkEvent {query, payload}
 
 combineEvent :: forall a. Monoid a => Event a -> Event a -> [Event a]
 combineEvent x y = headX <> headY <> overlap <> tailY <> tailX

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -25,10 +25,11 @@ data Event a = MkEvent
   , payload :: a
   } deriving (Eq, Show, Functor)
 
-data SignalEvent a = MkSignalEvent
-  { support :: Interval
-  , event :: Event a
-  } deriving (Eq, Show, Functor)
+type SignalEvent a = Event (Event a)
+-- data SignalEvent a = MkSignalEvent
+--   { support :: Interval
+--   , event :: Event a
+--   } deriving (Eq, Show, Functor)
 
 type Signal a = Interval -> [SignalEvent a] -- A signal is defined by the "integral" of a sampling function
 
@@ -57,52 +58,116 @@ instance QC.Arbitrary a => QC.Arbitrary (Event a) where
     payload <- QC.arbitrary
     return MkEvent {query, payload}
 
-split :: SignalEvent (a -> b) -> SignalEvent a -> [SignalEvent b]
-split f x =
+split :: forall a. Monoid a => Event a -> Event a -> [Event a]
+split x y =
   let
-    MkSignalEvent { support = supportF , event = MkEvent { query = queryF, payload = payloadF } } = f
-    MkSignalEvent { support = supportX, event = MkEvent { query = queryX, payload = payloadX } } = x
+    MkEvent { query = MkInterval startX endX, payload = payloadX } = x
+    MkEvent { query = MkInterval startY endY, payload = payloadY } = y
+    overlap =
+      let
+        start = max startX startY
+        end = min endX endY
+      in
+        -- if start > end then [] else
+        return $ MkEvent { query = MkInterval start end, payload = payloadX <> payloadY }
+
+    tailEndY =
+      let
+        start = endX
+        end = endY
+      in
+        if start >= end
+        then []
+        else return $ MkEvent { query = MkInterval start end, payload = payloadY }
+
+    tailEndX =
+      let
+        start = endY
+        end = endX
+      in
+        if start >= end
+        then []
+        else return $ MkEvent { query = MkInterval start end, payload = payloadX }
+
+    headEndX =
+      let
+        start = startX
+        end = startY
+      in
+        if start >= end
+        then []
+        else return $ MkEvent { query = MkInterval start end, payload = payloadX }
+
+    headEndY =
+      let
+        start = startY
+        end = startX
+      in
+        if start >= end
+        then []
+        else return $ MkEvent { query = MkInterval start end, payload = payloadY }
   in
-    do
-      return $ MkSignalEvent { support = supportX, event = MkEvent { query = queryX, payload = payloadF payloadX } }
+    headEndX <> headEndY <> overlap <> tailEndY <> tailEndX
 
-embed :: a -> Signal a
-embed x (MkInterval queryStart queryEnd) = do
-  let
-    start = (fromIntegral @Integer) . floor $ queryStart
-    end = (fromIntegral @Integer) . ceiling $ queryEnd
-  beat <- [start..end - 1]
-  return MkSignalEvent { support = MkInterval beat (beat + 1), event = pure x }
+-- embed :: a -> Signal a
+-- embed x = pruneSignal $ \(MkInterval queryStart queryEnd) -> do
+--   let
+--     start = (fromIntegral @Integer) . floor $ queryStart
+--     end = (fromIntegral @Integer) . ceiling $ queryEnd
+--   beat <- [start..end - 1]
+--   return MkSignalEvent { support = MkInterval beat (beat + 1), event = pure x }
+
+-- split :: forall a. Monoid a => SignalEvent a -> SignalEvent a -> [SignalEvent a]
+-- split f x =
+--   let
+--     startX :: Time
+--     endX :: Time
+--     MkSignalEvent { onset = startX, event = MkEvent { query = queryX, payload = payloadX } } = x
+--     endX = startX + dur queryX
+
+--     startY :: Time
+--     endY :: Time
+--     MkSignalEvent { onset = startY , event = MkEvent { query = queryY, payload = payloadY } } = f
+--     endY = startY + dur queryY
+
+--     overlap :: [SignalEvent a]
+--     overlap =
+--       let
+--         start = max startX startY
+--         end = min endX endY
+--       in
+--         [ MkSignalEvent { onset = start, event = MkEvent {query = queryX, payload = payloadX <> payloadY } } ]
+--   in
+--     overlap
 
 
+-- pruneSignal :: Signal a -> Signal a
+-- pruneSignal signal (MkInterval queryStart queryEnd) = filter inBounds $ signal (MkInterval queryStart queryEnd)
+--   where
+--     inBounds MkSignalEvent {support = MkInterval{start}} = start >= queryStart && start < queryEnd
 
-prune :: Signal a -> Signal a
-prune signal (MkInterval queryStart queryEnd) = filter inBounds $ signal (MkInterval queryStart queryEnd)
-  where
-    inBounds MkSignalEvent {support = MkInterval{start}} = start >= queryStart && start < queryEnd
+-- -- | shift forward in time
+-- shift :: Time -> Signal a -> Signal a
+-- shift t f = f
+--   & lmap (\MkInterval{start, end} -> MkInterval { start = start - t, end = end - t })
+--   & rmap (fmap $ \ev@MkSignalEvent { support = MkInterval start end } -> ev { support = MkInterval (start + t) (end + t) })
 
--- | shift forward in time
-shift :: Time -> Signal a -> Signal a
-shift t f = f
-  & lmap (\MkInterval{start, end} -> MkInterval { start = start - t, end = end - t })
-  & rmap (fmap $ \ev@MkSignalEvent { support = MkInterval start end } -> ev { support = MkInterval (start + t) (end + t) })
+-- stack :: [Signal a] -> Signal a
+-- stack sigs query = do
+--   sig <- sigs
+--   sig query
 
-stack :: [Signal a] -> Signal a
-stack sigs query = do
-  sig <- sigs
-  sig query
+-- interleave :: [Signal a] -> Signal a
+-- interleave sigs query = do
+--   let (fromIntegral -> len) = length sigs
+--   (sig, n) <- zip sigs [0..]
+--   shift (n/len) sig query
 
-interleave :: [Signal a] -> Signal a
-interleave sigs query = do
-  let (fromIntegral -> len) = length sigs
-  (sig, n) <- zip sigs [0..]
-  shift (n/len) sig query
-
--- | scale faster in time
-fast :: Rational -> Signal a -> Signal a
-fast n sig = sig
-  & lmap (\MkInterval{start, end} -> MkInterval { start = start * n, end = end * n })
-  & rmap (fmap $ \ev@MkSignalEvent { support = MkInterval start end } -> ev { support = MkInterval (start / n) (end / n) })
+-- -- | scale faster in time
+-- fast :: Rational -> Signal a -> Signal a
+-- fast n sig = sig
+--   & lmap (\MkInterval{start, end} -> MkInterval { start = start * n, end = end * n })
+--   & rmap (fmap $ \ev@MkSignalEvent { support = MkInterval start end } -> ev { support = MkInterval (start / n) (end / n) })
 
 -- ap ::  Signal (a -> b) -> Signal a -> Signal b
 -- ap sigF (prune -> sigX) = prune $ \query0 ->  do

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -44,92 +44,119 @@ spec = do
           let (fmap (<>) -> u, fmap (<>) -> v, x) = input
           in (pure (.) <*> u <*> v <*> x) == (u <*> (v <*> x))
 
+    -- describe "embed" $ do
+    --   let pat = embed ()
+    --   it "should work" $ do
+    --     pat (MkInterval 0 1) `shouldBe`     [MkSignalEvent (MkInterval 0 1) (pure ())]
+    --     pat (MkInterval 0 2) `shouldBe`     [MkSignalEvent (MkInterval 0 1) (pure ()), MkSignalEvent (MkInterval 1 2) (pure ())]
+    --     pat (MkInterval 0.5 1.5) `shouldBe` [MkSignalEvent (MkInterval 1 2) (pure ())]
+    --     pat (MkInterval 0.5 2.5) `shouldBe` [MkSignalEvent (MkInterval 1 2) (pure ()), MkSignalEvent (MkInterval 2 3) (pure ())]
+
+    --   it "starts of events should be less than query ends" $ property $ \query@MkInterval{end} ->
+    --       [] == filter (\MkSignalEvent { support = MkInterval s _ } -> s >= end) (pat query)
+
+    --   it "ends of events should be greater than query starts" $ property $ \query@MkInterval{start} ->
+    --       [] == filter (\MkSignalEvent { support = MkInterval _ e } -> e <= start) (pat query)
+
+    --   it "should have transparently divisible queries" $ do
+    --     (pat (MkInterval 0 0)   <> pat (MkInterval 0 1)) `shouldBe` pat (MkInterval 0 1)
+    --     (pat (MkInterval 0 1)   <> pat (MkInterval 1 1)) `shouldBe` pat (MkInterval 0 1)
+    --     (pat (MkInterval 0 0.5) <> pat (MkInterval 0.5 1.0)) `shouldBe` pat (MkInterval 0 1)
+    --     (pat (MkInterval 0 0.3) <> pat (MkInterval 0.3 1.3) <> pat (MkInterval 1.3 2)) `shouldBe` pat (MkInterval 0 2)
+
     describe "split" $ do
       it "works" $ do
         let
-          eventF = MkSignalEvent { support = MkInterval 0 1, event = pure id}
-          eventX = MkSignalEvent { support = MkInterval 0 1, event = pure ()}
-        split eventF eventX `shouldBe` [eventX]
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
+        (eventX `split` eventY) `shouldBe` [ MkEvent { query = MkInterval 0 1, payload = "HelloWorld" } ]
 
-      it "works" $ do
+      it "works 2" $ do
         let
-          eventF = MkSignalEvent { support = MkInterval 0 1, event = pure id}
-          eventX = MkSignalEvent { support = MkInterval 0 1, event = pure ()}
-        split eventF eventX `shouldBe` [eventX]
-
-    describe "embed" $ do
-      let pat = embed ()
-      it "should work" $ do
-        pat (MkInterval 0 1) `shouldBe`     [MkSignalEvent (MkInterval 0 1) (pure ())]
-        pat (MkInterval 0 2) `shouldBe`     [MkSignalEvent (MkInterval 0 1) (pure ()), MkSignalEvent (MkInterval 1 2) (pure ())]
-        pat (MkInterval 0.5 1.5) `shouldBe` [MkSignalEvent (MkInterval 0 1) (pure ()), MkSignalEvent (MkInterval 1 2) (pure ())]
-        pat (MkInterval 0.5 2.5) `shouldBe` [MkSignalEvent (MkInterval 0 1) (pure ()), MkSignalEvent (MkInterval 1 2) (pure ()), MkSignalEvent (MkInterval 2 3) (pure ())]
-
-      it "starts of events should be less than query ends" $ property $ \query@MkInterval{end} ->
-          [] == filter (\MkSignalEvent { support = MkInterval s _ } -> s >= end) (pat query)
-
-      it "ends of events should be greater than query starts" $ property $ \query@MkInterval{start} ->
-          [] == filter (\MkSignalEvent { support = MkInterval _ e } -> e <= start) (pat query)
-
-      describe "when pruned" $ do
-        let pat = embed () & prune
-
-        it "should have transparently divisible queries" $ do
-          (pat (MkInterval 0 0)   <> pat (MkInterval 0 1)) `shouldBe` pat (MkInterval 0 1)
-          (pat (MkInterval 0 1)   <> pat (MkInterval 1 1)) `shouldBe` pat (MkInterval 0 1)
-          (pat (MkInterval 0 0.5) <> pat (MkInterval 0.5 1.0)) `shouldBe` pat (MkInterval 0 1)
-          (pat (MkInterval 0 0.3) <> pat (MkInterval 0.3 1.3) <> pat (MkInterval 1.3 2)) `shouldBe` pat (MkInterval 0 2)
-
-    describe "fast" $ do
-      let pat = embed ()
-      it "should noop for fast 1" $ do
-        (fast 1 pat) (MkInterval 0 1)  `shouldBe` pat (MkInterval 0 1)
-
-      it "should work for fast 2" $ do
-        (fast 2 pat) (MkInterval 0 0.5) `shouldBe` [MkSignalEvent (MkInterval 0 0.5) (pure ())]
-        (fast 2 pat) (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 0.5) (pure ()), MkSignalEvent (MkInterval 0.5 1) (pure ())]
-        (fast 2 pat) (MkInterval 1 2) `shouldBe`   [MkSignalEvent (MkInterval 1 1.5) (pure ()), MkSignalEvent (MkInterval 1.5 2) (pure ())]
-
-      it "should work for fast 3" $ do
-        (fast 3 pat) (MkInterval 0 (1/3)) `shouldBe`     [MkSignalEvent (MkInterval 0 (1/3)) (pure ())]
-        (fast 3 pat) (MkInterval 0 1) `shouldBe`         [MkSignalEvent (MkInterval 0 (1/3)) (pure ()), MkSignalEvent (MkInterval (1/3) (2/3)) (pure ()), MkSignalEvent (MkInterval (2/3) 1) (pure ())]
-        (fast 3 pat) (MkInterval (2/3) (4/3)) `shouldBe` [MkSignalEvent (MkInterval (2/3) 1) (pure ()), MkSignalEvent (MkInterval 1 (4/3)) (pure ())]
-
-      it "should noop for fast 0.5" $ do
-        (fast 0.5 pat) (MkInterval 0 1) `shouldBe` [MkSignalEvent (MkInterval 0 2) (pure ())]
-        (fast 0.5 pat) (MkInterval 0 2) `shouldBe` [MkSignalEvent (MkInterval 0 2) (pure ())]
-
-    describe "shift" $ do
-      let pat = embed ()
-      it "should noop for shift 0" $ do
-        (shift 0 pat) (MkInterval 0 1)  `shouldBe` pat (MkInterval 0 1)
-
-      it "should work" $ do
-        (shift 0 pat)   (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 1) (pure ())]
-        (shift 0.5 pat) (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval (-1/2) (1/2)) (pure ()), MkSignalEvent (MkInterval (1/2) (3/2)) (pure ())]
-        (shift 1 pat)   (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 1) (pure ())]
-
-      it "should shift forwards in time" $ do
-        (shift 0.25 pat) (MkInterval 0 1)  `shouldBe` [MkSignalEvent (MkInterval (-3/4) (1/4)) (pure ()), MkSignalEvent (MkInterval (1/4) (5/4)) (pure ())]
-
-    describe "stack" $ do
-      let pat = embed ()
-      it "should stack patterns" $ do
-        stack [(shift 0.25 pat), (shift 0.5 pat)] (MkInterval 0 1) `shouldBe`
-          [ MkSignalEvent (MkInterval (-3/4) (1/4)) (pure ())
-          , MkSignalEvent (MkInterval (1/4) (5/4)) (pure ())
-          , MkSignalEvent (MkInterval (-1/2) (1/2)) (pure ())
-          , MkSignalEvent (MkInterval (1/2) (3/2)) (pure ())
+          eventX = MkEvent { query = MkInterval 0 0.5, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 0.5, payload = "HelloWorld" }
+          , MkEvent { query = MkInterval 0.5 1, payload = "World" }
           ]
 
-    describe "interleave" $ do
-      let pat = embed ()
-      it "should noop for 1" $ do
-        interleave [pat] (MkInterval 0 1) `shouldBe` pat (MkInterval 0 1)
+      it "works 3" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0 0.5, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 0.5, payload = "HelloWorld" }
+          , MkEvent { query = MkInterval 0.5 1, payload = "Hello" }
+          ]
 
-      it "should stack patterns, shifted" $ do
-        interleave [pat, pat]      (MkInterval 0 1) `shouldBe` stack [(shift 0 pat), (shift 0.5 pat)] (MkInterval 0 1)
-        interleave [pat, pat, pat] (MkInterval 0 1) `shouldBe` stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)] (MkInterval 0 1)
+      it "works 4" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0.5 1, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 0.5, payload = "Hello" }
+          , MkEvent { query = MkInterval 0.5 1, payload = "HelloWorld" }
+          ]
+
+      it "works 5" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0.5 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 0.5, payload = "World" }
+          , MkEvent { query = MkInterval 0.5 1, payload = "HelloWorld" }
+          ]
+
+    -- describe "fast" $ do
+    --   let pat = embed ()
+    --   it "should noop for fast 1" $ do
+    --     (fast 1 pat) (MkInterval 0 1)  `shouldBe` pat (MkInterval 0 1)
+
+    --   it "should work for fast 2" $ do
+    --     (fast 2 pat) (MkInterval 0 0.5) `shouldBe` [MkSignalEvent (MkInterval 0 0.5) (pure ())]
+    --     (fast 2 pat) (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 0.5) (pure ()), MkSignalEvent (MkInterval 0.5 1) (pure ())]
+    --     (fast 2 pat) (MkInterval 1 2) `shouldBe`   [MkSignalEvent (MkInterval 1 1.5) (pure ()), MkSignalEvent (MkInterval 1.5 2) (pure ())]
+
+    --   it "should work for fast 3" $ do
+    --     (fast 3 pat) (MkInterval 0 (1/3)) `shouldBe`     [MkSignalEvent (MkInterval 0 (1/3)) (pure ())]
+    --     (fast 3 pat) (MkInterval 0 1) `shouldBe`         [MkSignalEvent (MkInterval 0 (1/3)) (pure ()), MkSignalEvent (MkInterval (1/3) (2/3)) (pure ()), MkSignalEvent (MkInterval (2/3) 1) (pure ())]
+    --     (fast 3 pat) (MkInterval (2/3) (4/3)) `shouldBe` [MkSignalEvent (MkInterval (2/3) 1) (pure ()), MkSignalEvent (MkInterval 1 (4/3)) (pure ())]
+
+    --   it "should noop for fast 0.5" $ do
+    --     (fast 0.5 pat) (MkInterval 0 1) `shouldBe` [MkSignalEvent (MkInterval 0 2) (pure ())]
+    --     (fast 0.5 pat) (MkInterval 0 2) `shouldBe` [MkSignalEvent (MkInterval 0 2) (pure ())]
+
+    -- describe "shift" $ do
+    --   let pat = embed ()
+    --   it "should noop for shift 0" $ do
+    --     (shift 0 pat) (MkInterval 0 1)  `shouldBe` pat (MkInterval 0 1)
+
+    --   it "should work" $ do
+    --     (shift 0 pat)   (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 1) (pure ())]
+    --     (shift 0.5 pat) (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval (-1/2) (1/2)) (pure ()), MkSignalEvent (MkInterval (1/2) (3/2)) (pure ())]
+    --     (shift 1 pat)   (MkInterval 0 1) `shouldBe`   [MkSignalEvent (MkInterval 0 1) (pure ())]
+
+    --   it "should shift forwards in time" $ do
+    --     (shift 0.25 pat) (MkInterval 0 1)  `shouldBe` [MkSignalEvent (MkInterval (-3/4) (1/4)) (pure ()), MkSignalEvent (MkInterval (1/4) (5/4)) (pure ())]
+
+    -- describe "stack" $ do
+    --   let pat = embed ()
+    --   it "should stack patterns" $ do
+    --     stack [(shift 0.25 pat), (shift 0.5 pat)] (MkInterval 0 1) `shouldBe`
+    --       [ MkSignalEvent (MkInterval (-3/4) (1/4)) (pure ())
+    --       , MkSignalEvent (MkInterval (1/4) (5/4)) (pure ())
+    --       , MkSignalEvent (MkInterval (-1/2) (1/2)) (pure ())
+    --       , MkSignalEvent (MkInterval (1/2) (3/2)) (pure ())
+    --       ]
+
+    -- describe "interleave" $ do
+    --   let pat = embed ()
+    --   it "should noop for 1" $ do
+    --     interleave [pat] (MkInterval 0 1) `shouldBe` pat (MkInterval 0 1)
+
+    --   it "should stack patterns, shifted" $ do
+    --     interleave [pat, pat]      (MkInterval 0 1) `shouldBe` stack [(shift 0 pat), (shift 0.5 pat)] (MkInterval 0 1)
+    --     interleave [pat, pat, pat] (MkInterval 0 1) `shouldBe` stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)] (MkInterval 0 1)
 
     -- describe "ap" $ do
     --   let pat = embed ()

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -65,13 +65,13 @@ spec = do
     --     (pat (MkInterval 0 0.3) <> pat (MkInterval 0.3 1.3) <> pat (MkInterval 1.3 2)) `shouldBe` pat (MkInterval 0 2)
 
     describe "split" $ do
-      it "works" $ do
+      it "works overlapped 1" $ do
         let
           eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
           eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
         (eventX `split` eventY) `shouldBe` [ MkEvent { query = MkInterval 0 1, payload = "HelloWorld" } ]
 
-      it "works 2" $ do
+      it "works overlapped 2" $ do
         let
           eventX = MkEvent { query = MkInterval 0 0.5, payload = "Hello"}
           eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
@@ -80,7 +80,7 @@ spec = do
           , MkEvent { query = MkInterval 0.5 1, payload = "World" }
           ]
 
-      it "works 3" $ do
+      it "works overlapped 3" $ do
         let
           eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
           eventY = MkEvent { query = MkInterval 0 0.5, payload = "World"}
@@ -89,7 +89,7 @@ spec = do
           , MkEvent { query = MkInterval 0.5 1, payload = "Hello" }
           ]
 
-      it "works 4" $ do
+      it "works overlapped 4" $ do
         let
           eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
           eventY = MkEvent { query = MkInterval 0.5 1, payload = "World"}
@@ -98,13 +98,50 @@ spec = do
           , MkEvent { query = MkInterval 0.5 1, payload = "HelloWorld" }
           ]
 
-      it "works 5" $ do
+      it "works overlapped 5" $ do
         let
           eventX = MkEvent { query = MkInterval 0.5 1, payload = "Hello"}
           eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
         (eventX `split` eventY) `shouldBe`
           [ MkEvent { query = MkInterval 0 0.5, payload = "World" }
           , MkEvent { query = MkInterval 0.5 1, payload = "HelloWorld" }
+          ]
+
+      it "works overlapped 6" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0.25 0.75, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 0.25, payload = "Hello" }
+          , MkEvent { query = MkInterval 0.25 0.75, payload = "HelloWorld" }
+          , MkEvent { query = MkInterval 0.75 1, payload = "Hello" }
+          ]
+
+      it "works when there are no overlaps" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 1 2, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 1, payload = "Hello" }
+          , MkEvent { query = MkInterval 1 2, payload = "World" }
+          ]
+
+      it "works when there are no overlaps 2" $ do
+        let
+          eventX = MkEvent { query = MkInterval 0 1, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 2 3, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 1, payload = "Hello" }
+          , MkEvent { query = MkInterval 2 3, payload = "World" }
+          ]
+
+      it "works when there are no overlaps 3" $ do
+        let
+          eventX = MkEvent { query = MkInterval 2 3, payload = "Hello"}
+          eventY = MkEvent { query = MkInterval 0 1, payload = "World"}
+        (eventX `split` eventY) `shouldBe`
+          [ MkEvent { query = MkInterval 0 1, payload = "World" }
+          , MkEvent { query = MkInterval 2 3, payload = "Hello" }
           ]
 
     -- describe "fast" $ do

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -9,7 +9,6 @@ module SyzygySpec where
 import Test.Hspec
 import Syzygy
 import qualified Test.QuickCheck as QC
-import Data.Function ((&))
 import Data.Monoid ((<>))
 
 spec :: Spec
@@ -17,23 +16,6 @@ spec = do
   describe "Syzygy" $ do
 
     describe "Event" $ do
-      -- describe "Applicative Instance" $ do
-      --   it "obeys the identity law" $ property $ \(event :: Event ()) ->
-      --     (pure id <*> event) ==  event
-
-      --   it "obeys the homomorphism law" $ do
-      --     let f = (, "hello")
-      --     let x = ()
-      --     (pure f <*> pure x) `shouldBe` pure @Event (f x)
-
-      --   it "obeys the interchange law" $ property $ \(query :: Interval)->
-      --     let u = MkEvent { query, payload = (,"hello") }
-      --     in (u <*> pure ()) == (pure ($()) <*> u)
-
-      --   it "obeys the composition law" $ property $ \(input :: (Event String, Event String, Event String)) ->
-      --     let (fmap (<>) -> u, fmap (<>) -> v, x) = input
-      --     in (pure (.) <*> u <*> v <*> x) == (u <*> (v <*> x))
-
       describe "combineEvent" $ do
         it "works overlapped 1" $ do
           let


### PR DESCRIPTION
Now a `Signal` is an endofunctor in the category of monoids, that maps any monoid `m` to the free monoid product ~`(℘(ℝ), U, ∅) x m`~ `(℘(ℝ), ∩, ℝ) x m`

Or something like that :p