### PR TITLE
SuperDirt Connector

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -12,6 +12,10 @@ extra-source-files:
 dependencies:
   - base >= 4.7 && < 5
   - profunctors
+  - vivid-osc
+  - bytestring
+  - time
+  - network
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ library:
 
 tests:
   syzygy-test:
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
     main: Spec.hs
     source-dirs: test
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -29,4 +29,5 @@ tests:
     dependencies:
       - syzygy
       - hspec
+      - hspec-expectations
       - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -18,12 +18,13 @@ dependencies:
   - network
 
 library:
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   source-dirs: src
   main: Syzygy.hs
 
 tests:
   syzygy-test:
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
     main: Spec.hs
     source-dirs: test
     dependencies:

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -136,7 +136,7 @@ makeAction MkEnv{superDirtSocket, clockRef, signalRef} cps = do
   modifyMVar_ clockRef (return . (+1))
   now <- Time.getCurrentTime
   signal <- readMVar signalRef
-  let oscEvents = querySignal now 1 (0, 1) signal
+  let oscEvents = querySignal now cps (0, 1) signal
   traverse (NetworkBS.send superDirtSocket . toOSCBundleTest) oscEvents
   threadDelay (floor $ recip cps * 1000000)
 

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -110,7 +110,6 @@ data Env = MkEnv
   , superDirtSocket :: Network.Socket
   , clockRef :: MVar Rational
   , signalRef :: MVar (Signal BS.ByteString)
-  , cps :: Rational
   }
 
 data Config = MkConfig
@@ -119,7 +118,7 @@ data Config = MkConfig
   }
 
 makeEnv :: Config -> IO Env
-makeEnv config@MkConfig{portNumber, cps} = do
+makeEnv config@MkConfig{portNumber } = do
   superDirtSocket <- _makeLocalUDPConnection portNumber
   clockRef <- newMVar (0 :: Rational)
   signalRef <- newMVar (mempty :: Signal BS.ByteString)
@@ -127,7 +126,7 @@ makeEnv config@MkConfig{portNumber, cps} = do
     sendEvents :: IO ()
     sendEvents = _makeSendEvents config env
 
-    env = MkEnv { superDirtSocket, clockRef, signalRef, sendEvents, cps }
+    env = MkEnv { superDirtSocket, clockRef, signalRef, sendEvents }
   return env
 
 _makeLocalUDPConnection :: Network.PortNumber -> IO Network.Socket

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -3,64 +3,35 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Syzygy where
 
 import Data.Profunctor
 import Data.Function ((&))
-import Data.Monoid
+-- import qualified Network.Socket.ByteString as SB
+-- import qualified Data.ByteString as B
+-- import qualified Data.ByteString.Builder as B
+import Control.Concurrent (threadDelay, forkIO)
+import Control.Concurrent.MVar
+import qualified Data.Time as Time
+
+import qualified Vivid.OSC as OSC
 
 type Time = Rational
 
 type Interval = (Time, Time)
 
 data Event a = MkEvent
-  { query :: (Time, Time)
+  { interval :: (Time, Time)
   , payload :: a
   } deriving (Eq, Show, Functor)
 
-newtype Signal a = MkSignal { signal :: Interval -> [Event a] } -- A signal is defined by the "integral" of a sampling function
-
-
-combineEvent :: forall a. Monoid a => Event a -> Event a -> [Event a]
-combineEvent x y = headX <> headY <> overlap <> tailY <> tailX
-  where
-    MkEvent { query = (startX, endX), payload = payloadX } = x
-    MkEvent { query = (startY, endY), payload = payloadY } = y
-    overlap = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadX <> payloadY }
-      where
-        start = max startX startY
-        end = min endX endY
-
-    tailY = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadY }
-      where
-        start = max startY endX
-        end = endY
-
-    tailX = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadX }
-      where
-        start = max startX endY
-        end = endX
-
-    headX = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadX }
-      where
-        start = startX
-        end = min endX startY
-
-    headY = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadY }
-      where
-        start = startY
-        end = min startX endY
-
-combineEventOverlap :: forall a. Monoid a => Event a -> Event a -> [Event a]
-combineEventOverlap x y = overlap
-  where
-    MkEvent { query = (startX, endX), payload = payloadX } = x
-    MkEvent { query = (startY, endY), payload = payloadY } = y
-    overlap = if start >= end then [] else return $ MkEvent { query = (start, end), payload = payloadX <> payloadY }
-      where
-        start = max startX startY
-        end = min endX endY
+-- | A signal is defined by the "integral" of a sampling function
+newtype Signal a = MkSignal { signal :: Interval -> [Event a] }
+  deriving (Functor, Monoid)
 
 embed :: a -> Signal a
 embed x = MkSignal $ \(queryStart, queryEnd) -> do
@@ -68,33 +39,14 @@ embed x = MkSignal $ \(queryStart, queryEnd) -> do
     start = (fromIntegral @Integer) . floor $ queryStart
     end = (fromIntegral @Integer) . ceiling $ queryEnd
   beat <- [start..end - 1]
-  return MkEvent { query = (beat, (beat + 1)), payload = x }
+  return MkEvent { interval = (beat, (beat + 1)), payload = x }
 
 pruneSignal :: Signal a -> Signal a
 pruneSignal (MkSignal sig) = MkSignal $ \(queryStart, queryEnd) ->
   let
-    inBounds MkEvent {query = (start, _)} = start >= queryStart && start < queryEnd
+    inBounds MkEvent {interval = (start, _)} = start >= queryStart && start < queryEnd
   in
     filter inBounds $ sig (queryStart, queryEnd)
-
-instance Monoid a => Monoid (Signal a) where
-  mempty = MkSignal $ \_ -> []
-
-  (MkSignal sigX) `mappend` (MkSignal sigY) = MkSignal $ \query ->
-    let
-      xs = sigX query
-    in
-      case xs of
-        [] -> sigY query
-        _ ->
-          let
-            f x@MkEvent{query=subQuery} acc = case sigY subQuery of
-              [] -> (pure x <> acc)
-              ys -> (<> acc) $ do
-                y <- ys
-                x `combineEventOverlap` y
-          in
-            foldr f [] xs
 
 -- | shift forward in time
 shift :: Time -> Signal a -> Signal a
@@ -102,7 +54,7 @@ shift t MkSignal {signal=originalSignal} = MkSignal {signal}
   where
     signal = originalSignal
       & lmap (\(start, end) -> (start - t, end - t ))
-      & rmap (fmap $ \ev@MkEvent { query = (start, end) } -> ev { query = (start + t, end + t) })
+      & rmap (fmap $ \ev@MkEvent { interval = (start, end) } -> ev { interval = (start + t, end + t) })
 
 -- | scale faster in time
 fast :: Rational -> Signal a -> Signal a
@@ -110,7 +62,7 @@ fast n MkSignal {signal=originalSignal} = MkSignal {signal}
   where
     signal = originalSignal
       & lmap (\(start, end) -> ( start * n, end * n ))
-      & rmap (fmap $ \ev@MkEvent { query = (start, end) } -> ev { query = (start / n, end / n) })
+      & rmap (fmap $ \ev@MkEvent { interval = (start, end) } -> ev { interval = (start / n, end / n) })
 
 -- | stack in parallel
 stack :: [Signal a] -> Signal a
@@ -124,3 +76,33 @@ interleave sigs = MkSignal $ \query -> do
   let (fromIntegral -> len) = length sigs
   (sig, n) <- zip sigs [0..]
   signal (shift (n/len) sig) query
+
+doOnce :: Rational -> IO () -> IO ()
+doOnce actionsPerSecond action = do
+  let
+    secondsPerAction = recip actionsPerSecond
+    picosecondsPerAction = secondsPerAction * 10^6
+  threadDelay $ floor picosecondsPerAction
+  action
+
+-- | Query a signal for once cycle at the given rate, relative to some absolute time
+querySignal :: forall a. Time.UTCTime -> Rational -> Interval -> Signal a -> [(Time.UTCTime, a)]
+querySignal now cps query MkSignal{signal} = fmap formatEvent events
+  where
+    queryStart :: Rational
+    (queryStart, _) = query
+
+    events :: [Event a]
+    events = signal query
+
+    formatEvent :: Event a -> (Time.UTCTime, a)
+    formatEvent MkEvent{interval=(start, _), payload} =
+      let
+        delay = (start - queryStart)  * (recip cps)
+        timestamp = Time.addUTCTime (fromRational delay) now
+      in
+        (timestamp, payload)
+
+ --   foo :: B.ByteString
+ --   foo = OSC.encodeOSC $ OSC.OSC "/play2" [OSC.OSC_S "cps", OSC.OSC_I 1, OSC.OSC_S "s", OSC.OSC_S "bd"]
+ -- print $ B.toLazyByteString $ B.byteStringHex foo

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,8 @@ resolver: lts-9.0
 
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- vivid-osc-0.3.0.0
 
 flags: {}
 

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -23,6 +23,10 @@ library
   build-depends:
       base >= 4.7 && < 5
     , profunctors
+    , vivid-osc
+    , bytestring
+    , time
+    , network
   exposed-modules:
       Syzygy
   other-modules:
@@ -37,6 +41,10 @@ test-suite syzygy-test
   build-depends:
       base >= 4.7 && < 5
     , profunctors
+    , vivid-osc
+    , bytestring
+    , time
+    , network
     , syzygy
     , hspec
     , QuickCheck

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -20,6 +20,7 @@ extra-source-files:
 library
   hs-source-dirs:
       src
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:
       base >= 4.7 && < 5
     , profunctors
@@ -38,7 +39,7 @@ test-suite syzygy-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:
       base >= 4.7 && < 5
     , profunctors

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -38,6 +38,7 @@ test-suite syzygy-test
   main-is: Spec.hs
   hs-source-dirs:
       test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >= 4.7 && < 5
     , profunctors

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -52,4 +52,5 @@ test-suite syzygy-test
     , QuickCheck
   other-modules:
       SyzygySpec
+      TestUtils
   default-language: Haskell2010

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -48,6 +48,7 @@ test-suite syzygy-test
     , network
     , syzygy
     , hspec
+    , hspec-expectations
     , QuickCheck
   other-modules:
       SyzygySpec

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -23,234 +23,231 @@ import qualified Test.QuickCheck as QC
 
 spec :: Spec
 spec = do
-  describe "Syzygy" $ do
-    describe "Signal" $ do
-      describe "embed" $ do
-        it "should work" $ do
-          let pat = embed ()
-          signal pat (0, 1) `shouldBe`     [MkEvent (0, 1) ()]
-          signal pat (0, 2) `shouldBe`     [MkEvent (0, 1) (), MkEvent (1, 2) ()]
-          signal pat (0.5, 1.5) `shouldBe` [MkEvent (0, 1) (), MkEvent (1, 2) ()]
-          signal pat (0.5, 2.5) `shouldBe` [MkEvent (0, 1) (), MkEvent (1, 2) (), MkEvent (2, 3) ()]
-
-        it "starts of events should be less than query ends" $ QC.property $ \query@(_, end) ->
-          let pat = embed () in
-          [] == filter (\MkEvent { interval = (s, _) } -> s >= end) (signal pat query)
-
-        it "ends of events should be greater than query starts" $ QC.property $ \query@(start, _) ->
-          let pat = embed () in
-          [] == filter (\MkEvent { interval = (_, e) } -> e <= start) (signal pat query)
-
-        it "should have transparently divisible queries when pruned" $ do
-          let pat = pruneSignal $ embed ()
-          (signal pat (0, 0)   <> signal pat (0, 1)) `shouldBe` signal pat (0, 1)
-          (signal pat (0, 1)   <> signal pat (1, 1)) `shouldBe` signal pat (0, 1)
-          (signal pat (0, 0.5) <> signal pat (0.5, 1.0)) `shouldBe` signal pat (0, 1)
-          (signal pat (0, 0.3) <> signal pat (0.3, 1.3) <> signal pat (1.3, 2)) `shouldBe` signal pat (0, 2)
-
-      describe "Monoid Instance" $ do
-        let
-          shouldEqualSignal :: (Show a, Monoid a, Eq a) => Signal a -> Signal a -> IO ()
-          shouldEqualSignal x y = signal x query `shouldBe` signal y query
-            where
-              query = (0, 1)
-
-          checkLeftUnitalLaw :: Signal () -> IO ()
-          checkLeftUnitalLaw x = (mempty <> x) `shouldEqualSignal` x
-
-          checkRightUnitalLaw :: Signal () -> IO ()
-          checkRightUnitalLaw x = (x <> mempty) `shouldEqualSignal` x
-
-          checkAssociativeLaw :: Signal String -> Signal String -> Signal String -> IO ()
-          checkAssociativeLaw x y z = (x <> (y <> z)) `shouldEqualSignal` ((x <> y) <> z)
-
-        it "obeys the left unital law" $ do
-          checkLeftUnitalLaw (embed ())
-          checkLeftUnitalLaw (fast 2 $ embed ())
-
-        it "obeys the right unital law" $ do
-          checkRightUnitalLaw (embed ())
-          checkRightUnitalLaw (fast 2 $ embed ())
-
-        it "obeys the associative law" $ do
-          checkAssociativeLaw (embed "a") (embed "b") (embed "c")
-          checkAssociativeLaw (fast 2 $ embed "a") (fast 3 $ embed "b") (fast 5 $ embed "c")
-
-    describe "pattern combinators" $ do
-      describe "fast" $ do
+  describe "Signal" $ do
+    describe "embed" $ do
+      it "should work" $ do
         let pat = embed ()
-        it "should noop for fast 1" $ do
-          signal (fast 1 pat) (0, 1)  `shouldBe` signal pat (0, 1)
+        signal pat (0, 1) `shouldBe`     [MkEvent (0, 1) ()]
+        signal pat (0, 2) `shouldBe`     [MkEvent (0, 1) (), MkEvent (1, 2) ()]
+        signal pat (0.5, 1.5) `shouldBe` [MkEvent (0, 1) (), MkEvent (1, 2) ()]
+        signal pat (0.5, 2.5) `shouldBe` [MkEvent (0, 1) (), MkEvent (1, 2) (), MkEvent (2, 3) ()]
 
-        it "should return appropriate events for fast 2" $ do
-          signal (fast 2 pat) (0, 0.5) `shouldBe` [MkEvent (0, 0.5) ()]
-          signal (fast 2 pat) (0, 1) `shouldBe`   [MkEvent (0, 0.5) (), MkEvent (0.5, 1) ()]
-          signal (fast 2 pat) (1, 2) `shouldBe`   [MkEvent (1, 1.5) (), MkEvent (1.5, 2) ()]
+      it "starts of events should be less than query ends" $ QC.property $ \query@(_, end) ->
+        let pat = embed () in
+        [] == filter (\MkEvent { interval = (s, _) } -> s >= end) (signal pat query)
 
-        it "should return appropriate events for fast 3" $ do
-          signal (fast 3 pat) (0, (1/3)) `shouldBe` [MkEvent (0, (1/3)) ()]
-          signal (fast 3 pat) (0, 1) `shouldBe`     [MkEvent (0, (1/3)) (), MkEvent ((1/3), (2/3)) (), MkEvent ((2/3), 1) ()]
-          signal (fast 3 pat) ((2/3), (4/3)) `shouldBe` [MkEvent ((2/3), 1) (), MkEvent (1, (4/3)) ()]
+      it "ends of events should be greater than query starts" $ QC.property $ \query@(start, _) ->
+        let pat = embed () in
+        [] == filter (\MkEvent { interval = (_, e) } -> e <= start) (signal pat query)
 
-        it "should return appropriate events for fast 0.5" $ do
-          signal (fast 0.5 pat) (0, 1) `shouldBe` [MkEvent (0, 2) ()]
-          signal (fast 0.5 pat) (0, 2) `shouldBe` [MkEvent (0, 2) ()]
+      it "should have transparently divisible queries when pruned" $ do
+        let pat = pruneSignal $ embed ()
+        (signal pat (0, 0)   <> signal pat (0, 1)) `shouldBe` signal pat (0, 1)
+        (signal pat (0, 1)   <> signal pat (1, 1)) `shouldBe` signal pat (0, 1)
+        (signal pat (0, 0.5) <> signal pat (0.5, 1.0)) `shouldBe` signal pat (0, 1)
+        (signal pat (0, 0.3) <> signal pat (0.3, 1.3) <> signal pat (1.3, 2)) `shouldBe` signal pat (0, 2)
 
-      describe "shift" $ do
-        let pat = embed ()
-        it "should noop for shift 0" $ do
-          signal (shift 0 pat) (0, 1)  `shouldBe` signal pat (0, 1)
-
-        it "should return appropriate events" $ do
-          signal (shift 0 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
-          signal (shift 0.5 pat) (0, 1) `shouldBe` [MkEvent ((-1/2), (1/2)) (), MkEvent ((1/2), (3/2)) ()]
-          signal (shift 1 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
-
-        it "should shift forwards in time" $ do
-          signal (shift 0.25 pat) (0, 1) `shouldBe` [MkEvent ((-3/4), (1/4)) (), MkEvent ((1/4), (5/4)) ()]
-
-      describe "stack" $ do
-        let pat = embed ()
-        it "should return appropriate events" $ do
-          signal (stack [(shift 0.25 pat), (shift 0.5 pat)]) (0, 1) `shouldBe`
-            [ MkEvent ((-3/4), (1/4)) ()
-            , MkEvent ((1/4), (5/4)) ()
-            , MkEvent ((-1/2), (1/2)) ()
-            , MkEvent ((1/2), (3/2)) ()
-            ]
-
-      describe "interleave" $ do
-        let pat = embed ()
-        it "should noop for 1" $ do
-          signal (interleave [pat]) (0, 1) `shouldBe` signal pat (0, 1)
-
-        it "should stack patterns, shifted" $ do
-          signal (interleave [pat, pat])      (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift 0.5 pat)]) (0, 1)
-          signal (interleave [pat, pat, pat]) (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)]) (0, 1)
-
-    describe "querySignal" $ do
+    describe "Monoid Instance" $ do
       let
-        cps :: Rational
-        cps = 1
+        shouldEqualSignal :: (Show a, Monoid a, Eq a) => Signal a -> Signal a -> IO ()
+        shouldEqualSignal x y = signal x query `shouldBe` signal y query
+          where
+            query = (0, 1)
 
-        query :: Interval
-        query = (0, 1)
+        checkLeftUnitalLaw :: Signal () -> IO ()
+        checkLeftUnitalLaw x = (mempty <> x) `shouldEqualSignal` x
 
-        sig :: Signal String
-        sig = fast 3 $ embed "hello"
+        checkRightUnitalLaw :: Signal () -> IO ()
+        checkRightUnitalLaw x = (x <> mempty) `shouldEqualSignal` x
 
-      it "returns the same payloads from querying the signal, but pruned" $ do
-        let
-          expectedPayloads :: [String]
-          expectedPayloads = (signal (pruneSignal sig) query)& fmap payload
-        now <- Time.getCurrentTime
-        let oscEvents = querySignal now cps query sig
-        (oscEvents & fmap snd) `shouldBe` expectedPayloads
+        checkAssociativeLaw :: Signal String -> Signal String -> Signal String -> IO ()
+        checkAssociativeLaw x y z = (x <> (y <> z)) `shouldEqualSignal` ((x <> y) <> z)
 
-      it "returns the correct future timestamps" $ do
-        now <- Time.getCurrentTime
-        let
-          event1, event2, event3 :: (Time.UTCTime, String)
-          [event1, event2, event3] = querySignal now cps query sig
+      it "obeys the left unital law" $ do
+        checkLeftUnitalLaw (embed ())
+        checkLeftUnitalLaw (fast 2 $ embed ())
 
-          -- | Difference from now in seconds, with a picosecond tolerance
-          shouldExpectDifferenceFromNow :: (Time.UTCTime, a) -> Time.NominalDiffTime -> IO ()
-          shouldExpectDifferenceFromNow oscEvent difference = do
-              let
-                (futureTimestamp, _) = oscEvent
-              (futureTimestamp `Time.diffUTCTime` now) `shouldBeAround` (difference, 1e-9)
+      it "obeys the right unital law" $ do
+        checkRightUnitalLaw (embed ())
+        checkRightUnitalLaw (fast 2 $ embed ())
 
-        event1 `shouldExpectDifferenceFromNow` (1 * 0/3)
-        event2 `shouldExpectDifferenceFromNow` (1 * 1/3)
-        event3 `shouldExpectDifferenceFromNow` (1 * 2/3)
+      it "obeys the associative law" $ do
+        checkAssociativeLaw (embed "a") (embed "b") (embed "c")
+        checkAssociativeLaw (fast 2 $ embed "a") (fast 3 $ embed "b") (fast 5 $ embed "c")
 
-    describe "sendEvents" $ do
+  describe "Pattern Combinators" $ do
+    describe "fast" $ do
+      let pat = embed ()
+      it "should noop for fast 1" $ do
+        signal (fast 1 pat) (0, 1)  `shouldBe` signal pat (0, 1)
+
+      it "should return appropriate events for fast 2" $ do
+        signal (fast 2 pat) (0, 0.5) `shouldBe` [MkEvent (0, 0.5) ()]
+        signal (fast 2 pat) (0, 1) `shouldBe`   [MkEvent (0, 0.5) (), MkEvent (0.5, 1) ()]
+        signal (fast 2 pat) (1, 2) `shouldBe`   [MkEvent (1, 1.5) (), MkEvent (1.5, 2) ()]
+
+      it "should return appropriate events for fast 3" $ do
+        signal (fast 3 pat) (0, (1/3)) `shouldBe` [MkEvent (0, (1/3)) ()]
+        signal (fast 3 pat) (0, 1) `shouldBe`     [MkEvent (0, (1/3)) (), MkEvent ((1/3), (2/3)) (), MkEvent ((2/3), 1) ()]
+        signal (fast 3 pat) ((2/3), (4/3)) `shouldBe` [MkEvent ((2/3), 1) (), MkEvent (1, (4/3)) ()]
+
+      it "should return appropriate events for fast 0.5" $ do
+        signal (fast 0.5 pat) (0, 1) `shouldBe` [MkEvent (0, 2) ()]
+        signal (fast 0.5 pat) (0, 2) `shouldBe` [MkEvent (0, 2) ()]
+
+    describe "shift" $ do
+      let pat = embed ()
+      it "should noop for shift 0" $ do
+        signal (shift 0 pat) (0, 1)  `shouldBe` signal pat (0, 1)
+
+      it "should return appropriate events" $ do
+        signal (shift 0 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
+        signal (shift 0.5 pat) (0, 1) `shouldBe` [MkEvent ((-1/2), (1/2)) (), MkEvent ((1/2), (3/2)) ()]
+        signal (shift 1 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
+
+      it "should shift forwards in time" $ do
+        signal (shift 0.25 pat) (0, 1) `shouldBe` [MkEvent ((-3/4), (1/4)) (), MkEvent ((1/4), (5/4)) ()]
+
+    describe "stack" $ do
+      let pat = embed ()
+      it "should return appropriate events" $ do
+        signal (stack [(shift 0.25 pat), (shift 0.5 pat)]) (0, 1) `shouldBe`
+          [ MkEvent ((-3/4), (1/4)) ()
+          , MkEvent ((1/4), (5/4)) ()
+          , MkEvent ((-1/2), (1/2)) ()
+          , MkEvent ((1/2), (3/2)) ()
+          ]
+
+    describe "interleave" $ do
+      let pat = embed ()
+      it "should noop for 1" $ do
+        signal (interleave [pat]) (0, 1) `shouldBe` signal pat (0, 1)
+
+      it "should stack patterns, shifted" $ do
+        signal (interleave [pat, pat])      (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift 0.5 pat)]) (0, 1)
+        signal (interleave [pat, pat, pat]) (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)]) (0, 1)
+
+  describe "querySignal" $ do
+    let
+      cps :: Rational
+      cps = 1
+
+      query :: Interval
+      query = (0, 1)
+
+      sig :: Signal String
+      sig = fast 3 $ embed "hello"
+
+    it "returns the same payloads from querying the signal, but pruned" $ do
       let
-        mkTestEnvWithNoHandler :: Rational -> IO Env
-        mkTestEnvWithNoHandler cps = mkTestEnv cps (\_ -> return ())
+        expectedPayloads :: [String]
+        expectedPayloads = (signal (pruneSignal sig) query)& fmap payload
+      now <- Time.getCurrentTime
+      let oscEvents = querySignal now cps query sig
+      (oscEvents & fmap snd) `shouldBe` expectedPayloads
 
-        mkTestEnv :: Rational -> (OSCBundle -> IO ()) -> IO Env
-        mkTestEnv cps handler = withMockOSCServer handler $ \portNumber -> makeEnv MkConfig{portNumber, cps}
+    it "returns the correct future timestamps" $ do
+      now <- Time.getCurrentTime
+      let
+        event1, event2, event3 :: (Time.UTCTime, String)
+        [event1, event2, event3] = querySignal now cps query sig
 
-      describe "timing" $ do
-        it "has a synchronous delay of (1/60)s when given rate of 60cps" $ do
-          MkEnv{sendEvents} <- mkTestEnvWithNoHandler 60
-          start <- Time.getCurrentTime
+        -- | Difference from now in seconds, with a picosecond tolerance
+        shouldExpectDifferenceFromNow :: (Time.UTCTime, a) -> Time.NominalDiffTime -> IO ()
+        shouldExpectDifferenceFromNow oscEvent difference = do
+            let
+              (futureTimestamp, _) = oscEvent
+            (futureTimestamp `Time.diffUTCTime` now) `shouldBeAround` (difference, 1e-9)
+
+      event1 `shouldExpectDifferenceFromNow` (1 * 0/3)
+      event2 `shouldExpectDifferenceFromNow` (1 * 1/3)
+      event3 `shouldExpectDifferenceFromNow` (1 * 2/3)
+
+  describe "sendEvents" $ do
+    let
+      mkTestEnvWithNoHandler :: Rational -> IO Env
+      mkTestEnvWithNoHandler cps = mkTestEnv cps (\_ -> return ())
+
+      mkTestEnv :: Rational -> (OSCBundle -> IO ()) -> IO Env
+      mkTestEnv cps handler = withMockOSCServer handler $ \portNumber -> makeEnv MkConfig{portNumber, cps}
+
+    it "increments the clockRef by one cycle" $ do
+      MkEnv{sendEvents, clockRef} <- mkTestEnvWithNoHandler 60
+      timeBefore <- readMVar clockRef
+      sendEvents
+      timeAfter <- readMVar clockRef
+      (timeAfter - timeBefore) `shouldBe` 1
+
+    describe "when talking to SuperDirt" $ do
+      let
+        cps :: Num a => a
+        cps = 60
+
+        -- | sends one cycle to the mock SuperDirt at 60cps
+        sendOneCycle :: Signal BS.ByteString -> IO (IO (), Chan OSCBundle)
+        sendOneCycle signal = do
+          (oscBundleChan :: Chan OSCBundle) <- newChan
+          MkEnv{sendEvents, signalRef} <- mkTestEnv cps $ \bundle -> do
+              writeChan oscBundleChan bundle
+          modifyMVar_ signalRef (const . return $ signal)
+          return (sendEvents, oscBundleChan)
+
+      it "can send an event to SuperDirt" $ do
+        (sendEvents, oscBundleChan) <- sendOneCycle (embed "bd")
+        now <- Time.getCurrentTime
+        do
           sendEvents
-          end <- Time.getCurrentTime
-          (end `Time.diffUTCTime` start) `shouldBeAround` (1/60, 2e-3)
+          do
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (0, 1e-3)
 
-        it "has a synchronous delay of (1/30)s when given rate of 30cps" $ do
-          MkEnv{sendEvents} <- mkTestEnvWithNoHandler 30
-          start <- Time.getCurrentTime
+      it "can send multiple event to SuperDirt in the same cycle" $ do
+        (sendEvents, oscBundleChan) <- sendOneCycle (interleave [ embed "bd", embed "sn" ])
+        now <- Time.getCurrentTime
+        do
           sendEvents
-          end <- Time.getCurrentTime
-          (end `Time.diffUTCTime` start) `shouldBeAround` (1/30, 2e-3)
-
-      it "increments the clockRef by one cycle" $ do
-        MkEnv{sendEvents, clockRef} <- mkTestEnvWithNoHandler 60
-        timeBefore <- readMVar clockRef
-        sendEvents
-        timeAfter <- readMVar clockRef
-        (timeAfter - timeBefore) `shouldBe` 1
-
-      describe "when talking to SuperDirt" $ do
-        let
-          cps :: Num a => a
-          cps = 60
-
-          -- | sends one cycle to the mock SuperDirt at 60cps
-          sendOneCycle :: Signal BS.ByteString -> IO (IO (), Chan OSCBundle)
-          sendOneCycle signal = do
-            (oscBundleChan :: Chan OSCBundle) <- newChan
-            MkEnv{sendEvents, signalRef} <- mkTestEnv cps $ \bundle -> do
-                writeChan oscBundleChan bundle
-            modifyMVar_ signalRef (const . return $ signal)
-            return (sendEvents, oscBundleChan)
-
-        it "can send an event to SuperDirt" $ do
-          (sendEvents, oscBundleChan) <- sendOneCycle (embed "bd")
-          now <- Time.getCurrentTime
+          delayOneCycle 60
           do
-            sendEvents
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (0, 1e-3)
-
-        it "can send multiple event to SuperDirt in the same cycle" $ do
-          (sendEvents, oscBundleChan) <- sendOneCycle (interleave [ embed "bd", embed "sn" ])
-          now <- Time.getCurrentTime
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
           do
-            sendEvents
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
 
-        it "can send multiple events in multiple cycles, when invoked multiple times" $ do
-          (sendEvents, oscBundleChan) <- sendOneCycle (interleave [ fast 0.5 $ embed "bd", embed "sn" ])
-          now <- Time.getCurrentTime
+      it "can send multiple events in multiple cycles, when invoked multiple times" $ do
+        (sendEvents, oscBundleChan) <- sendOneCycle (interleave [ fast 0.5 $ embed "bd", embed "sn" ])
+        now <- Time.getCurrentTime
+        do
+          sendEvents
+          delayOneCycle 60
           do
-            sendEvents
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
           do
-            sendEvents
-            do
-              OSCBundle timestamp [Right message] <- readChan oscBundleChan
-              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 3/2, 1e-3)
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+        do
+          sendEvents
+          delayOneCycle 60
+          do
+            OSCBundle timestamp [Right message] <- readChan oscBundleChan
+            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 3/2, 1e-3)
 
-    describe "when running sendEvents on loop" $ do
-      it "has minimal clock drift" $ pending
+  describe "delayOneCycle" $ do
+    it "delays by one second given 1 cps" $ do
+      timeBefore <- Time.getCurrentTime
+      delayOneCycle 1
+      timeAfter <- Time.getCurrentTime
+      (timeAfter `Time.diffUTCTime` timeBefore) `shouldBeAround` (1, 1e-2)
+
+    it "delays by (1/60) second given 60 cps" $ do
+      timeBefore <- Time.getCurrentTime
+      delayOneCycle 60
+      timeAfter <- Time.getCurrentTime
+      (timeAfter `Time.diffUTCTime` timeBefore) `shouldBeAround` (1/60, 1e-2)

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -22,11 +22,23 @@ import qualified Data.ByteString as BS
 import qualified Test.QuickCheck as QC
 import qualified Network.Socket as Network
 import qualified Network.Socket.ByteString as NetworkBS
+import qualified Test.Hspec.Expectations
 
--- FIXME: write better hspec matcher
-shouldBeAround :: (Ord a, Num a) => a -> (a, a) -> IO ()
+shouldBeAround :: (HasCallStack, Ord a, Num a, Show a) => a -> (a, a) -> IO ()
 shouldBeAround value (expectedValue, tolerance) =
-  abs (value - expectedValue) < tolerance `shouldBe` True
+  let difference = abs (value - expectedValue)
+  in
+    if difference < tolerance
+    then return ()
+    else Test.Hspec.Expectations.expectationFailure
+      $ "expected "
+      <> show value
+      <> " to equal "
+      <> show expectedValue
+      <> " with a tolerance of "
+      <> show tolerance
+      <> ", when a difference of "
+      <> show difference <> " was found"
 
 withMockSuperDirtServer :: (OSCBundle -> IO ()) -> (Network.PortNumber -> IO a) -> IO a
 withMockSuperDirtServer handleOSCBundle cont = do
@@ -91,56 +103,57 @@ spec = do
           checkAssociativeLaw (embed "a") (embed "b") (embed "c")
           checkAssociativeLaw (fast 2 $ embed "a") (fast 3 $ embed "b") (fast 5 $ embed "c")
 
-    describe "fast" $ do
-      let pat = embed ()
-      it "should noop for fast 1" $ do
-        signal (fast 1 pat) (0, 1)  `shouldBe` signal pat (0, 1)
+    describe "pattern combinators" $ do
+      describe "fast" $ do
+        let pat = embed ()
+        it "should noop for fast 1" $ do
+          signal (fast 1 pat) (0, 1)  `shouldBe` signal pat (0, 1)
 
-      it "should work for fast 2" $ do
-        signal (fast 2 pat) (0, 0.5) `shouldBe` [MkEvent (0, 0.5) ()]
-        signal (fast 2 pat) (0, 1) `shouldBe`   [MkEvent (0, 0.5) (), MkEvent (0.5, 1) ()]
-        signal (fast 2 pat) (1, 2) `shouldBe`   [MkEvent (1, 1.5) (), MkEvent (1.5, 2) ()]
+        it "should work for fast 2" $ do
+          signal (fast 2 pat) (0, 0.5) `shouldBe` [MkEvent (0, 0.5) ()]
+          signal (fast 2 pat) (0, 1) `shouldBe`   [MkEvent (0, 0.5) (), MkEvent (0.5, 1) ()]
+          signal (fast 2 pat) (1, 2) `shouldBe`   [MkEvent (1, 1.5) (), MkEvent (1.5, 2) ()]
 
-      it "should work for fast 3" $ do
-        signal (fast 3 pat) (0, (1/3)) `shouldBe` [MkEvent (0, (1/3)) ()]
-        signal (fast 3 pat) (0, 1) `shouldBe`     [MkEvent (0, (1/3)) (), MkEvent ((1/3), (2/3)) (), MkEvent ((2/3), 1) ()]
-        signal (fast 3 pat) ((2/3), (4/3)) `shouldBe` [MkEvent ((2/3), 1) (), MkEvent (1, (4/3)) ()]
+        it "should work for fast 3" $ do
+          signal (fast 3 pat) (0, (1/3)) `shouldBe` [MkEvent (0, (1/3)) ()]
+          signal (fast 3 pat) (0, 1) `shouldBe`     [MkEvent (0, (1/3)) (), MkEvent ((1/3), (2/3)) (), MkEvent ((2/3), 1) ()]
+          signal (fast 3 pat) ((2/3), (4/3)) `shouldBe` [MkEvent ((2/3), 1) (), MkEvent (1, (4/3)) ()]
 
-      it "should work for fast 0.5" $ do
-        signal (fast 0.5 pat) (0, 1) `shouldBe` [MkEvent (0, 2) ()]
-        signal (fast 0.5 pat) (0, 2) `shouldBe` [MkEvent (0, 2) ()]
+        it "should work for fast 0.5" $ do
+          signal (fast 0.5 pat) (0, 1) `shouldBe` [MkEvent (0, 2) ()]
+          signal (fast 0.5 pat) (0, 2) `shouldBe` [MkEvent (0, 2) ()]
 
-    describe "shift" $ do
-      let pat = embed ()
-      it "should noop for shift 0" $ do
-        signal (shift 0 pat) (0, 1)  `shouldBe` signal pat (0, 1)
+      describe "shift" $ do
+        let pat = embed ()
+        it "should noop for shift 0" $ do
+          signal (shift 0 pat) (0, 1)  `shouldBe` signal pat (0, 1)
 
-      it "should work" $ do
-        signal (shift 0 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
-        signal (shift 0.5 pat) (0, 1) `shouldBe` [MkEvent ((-1/2), (1/2)) (), MkEvent ((1/2), (3/2)) ()]
-        signal (shift 1 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
+        it "should work" $ do
+          signal (shift 0 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
+          signal (shift 0.5 pat) (0, 1) `shouldBe` [MkEvent ((-1/2), (1/2)) (), MkEvent ((1/2), (3/2)) ()]
+          signal (shift 1 pat)   (0, 1) `shouldBe` [MkEvent (0, 1) ()]
 
-      it "should shift forwards in time" $ do
-        signal (shift 0.25 pat) (0, 1) `shouldBe` [MkEvent ((-3/4), (1/4)) (), MkEvent ((1/4), (5/4)) ()]
+        it "should shift forwards in time" $ do
+          signal (shift 0.25 pat) (0, 1) `shouldBe` [MkEvent ((-3/4), (1/4)) (), MkEvent ((1/4), (5/4)) ()]
 
-    describe "stack" $ do
-      let pat = embed ()
-      it "should stack patterns" $ do
-        signal (stack [(shift 0.25 pat), (shift 0.5 pat)]) (0, 1) `shouldBe`
-          [ MkEvent ((-3/4), (1/4)) ()
-          , MkEvent ((1/4), (5/4)) ()
-          , MkEvent ((-1/2), (1/2)) ()
-          , MkEvent ((1/2), (3/2)) ()
-          ]
+      describe "stack" $ do
+        let pat = embed ()
+        it "should stack patterns" $ do
+          signal (stack [(shift 0.25 pat), (shift 0.5 pat)]) (0, 1) `shouldBe`
+            [ MkEvent ((-3/4), (1/4)) ()
+            , MkEvent ((1/4), (5/4)) ()
+            , MkEvent ((-1/2), (1/2)) ()
+            , MkEvent ((1/2), (3/2)) ()
+            ]
 
-    describe "interleave" $ do
-      let pat = embed ()
-      it "should noop for 1" $ do
-        signal (interleave [pat]) (0, 1) `shouldBe` signal pat (0, 1)
+      describe "interleave" $ do
+        let pat = embed ()
+        it "should noop for 1" $ do
+          signal (interleave [pat]) (0, 1) `shouldBe` signal pat (0, 1)
 
-      it "should stack patterns, shifted" $ do
-        signal (interleave [pat, pat])      (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift 0.5 pat)]) (0, 1)
-        signal (interleave [pat, pat, pat]) (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)]) (0, 1)
+        it "should stack patterns, shifted" $ do
+          signal (interleave [pat, pat])      (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift 0.5 pat)]) (0, 1)
+          signal (interleave [pat, pat, pat]) (0, 1) `shouldBe` signal (stack [(shift 0 pat), (shift (1/3) pat), (shift (2/3) pat)]) (0, 1)
 
     describe "querySignal" $ do
       let
@@ -179,93 +192,94 @@ spec = do
         event3 `shouldExpectDifferenceFromNow` (1 * 2/3)
 
 
-  describe "action" $ do
-    let
-      mkTestEnvWithNoHandler :: IO Env
-      mkTestEnvWithNoHandler = mkTestEnv (\_ -> return ())
-
-      mkTestEnv :: (OSCBundle -> IO ()) -> IO Env
-      mkTestEnv handler = withMockSuperDirtServer handler $ makeEnv
-
-    describe "timing" $ do
-      it "has a synchronous delay of (1/60)s when given rate of 60cps" $ do
-        MkEnv{action} <- mkTestEnvWithNoHandler
-        start <- Time.getCurrentTime
-        action 60
-        end <- Time.getCurrentTime
-        (end `Time.diffUTCTime` start) `shouldBeAround` (1/60, 2e-3)
-
-      it "has a synchronous delay of (1/30)s when given rate of 30cps" $ do
-        MkEnv{action} <- mkTestEnvWithNoHandler
-        start <- Time.getCurrentTime
-        action 30
-        end <- Time.getCurrentTime
-        (end `Time.diffUTCTime` start) `shouldBeAround` (1/30, 2e-3)
-
-    it "increments the clockRef by one cycle" $ do
-      MkEnv{action, clockRef} <- mkTestEnvWithNoHandler
-      before <- readMVar clockRef
-      action 60
-      after <- readMVar clockRef
-      (after - before) `shouldBe` 1
-
-    describe "when talking to SuperDirt" $ do
+    -- FIXME: rename
+    describe "action" $ do
       let
-        cps :: Num a => a
-        cps = 60
+        mkTestEnvWithNoHandler :: IO Env
+        mkTestEnvWithNoHandler = mkTestEnv (\_ -> return ())
 
-        -- | sends one cycle to the mock SuperDirt at 60cps
-        sendOneCycle :: Signal BS.ByteString -> IO (IO (), Chan OSCBundle)
-        sendOneCycle signal = do
-          (oscBundleChan :: Chan OSCBundle) <- newChan
-          MkEnv{action, clockRef, signalRef} <- mkTestEnv $ \bundle -> do
-              writeChan oscBundleChan bundle
-          modifyMVar_ signalRef (const . return $ signal)
-          return (action cps, oscBundleChan)
+        mkTestEnv :: (OSCBundle -> IO ()) -> IO Env
+        mkTestEnv handler = withMockSuperDirtServer handler $ makeEnv
 
-      it "can send an event to SuperDirt" $ id @ (IO ()) $ do
-        (action, oscBundleChan) <- sendOneCycle (embed "bd")
-        now <- Time.getCurrentTime
-        do
-          action
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (0, 1e-3)
+      describe "timing" $ do
+        it "has a synchronous delay of (1/60)s when given rate of 60cps" $ do
+          MkEnv{action} <- mkTestEnvWithNoHandler
+          start <- Time.getCurrentTime
+          action 60
+          end <- Time.getCurrentTime
+          (end `Time.diffUTCTime` start) `shouldBeAround` (1/60, 2e-3)
 
-      it "can send multiple event to SuperDirt in the same cycle" $ id @ (IO ()) $ do
-        (action, oscBundleChan) <- sendOneCycle (interleave [ embed "bd", embed "sn" ])
-        now <- Time.getCurrentTime
-        do
-          action
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+        it "has a synchronous delay of (1/30)s when given rate of 30cps" $ do
+          MkEnv{action} <- mkTestEnvWithNoHandler
+          start <- Time.getCurrentTime
+          action 30
+          end <- Time.getCurrentTime
+          (end `Time.diffUTCTime` start) `shouldBeAround` (1/30, 2e-3)
 
-      it "can send multiple events in multiple cycles, when invoked multiple times" $ do
-        (action, oscBundleChan) <- sendOneCycle (interleave [ fast 0.5 $ embed "bd", embed "sn" ])
-        now <- Time.getCurrentTime
-        do
-          action
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
-        do
-          action
-          do
-            OSCBundle timestamp [Right message] <- readChan oscBundleChan
-            message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
-            (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 3/2, 1e-3)
+      it "increments the clockRef by one cycle" $ do
+        MkEnv{action, clockRef} <- mkTestEnvWithNoHandler
+        before <- readMVar clockRef
+        action 60
+        after <- readMVar clockRef
+        (after - before) `shouldBe` 1
 
-  describe "when running the action on loop" $ do
-    it "has minimal clock drift" $ pending
+      describe "when talking to SuperDirt" $ do
+        let
+          cps :: Num a => a
+          cps = 60
+
+          -- | sends one cycle to the mock SuperDirt at 60cps
+          sendOneCycle :: Signal BS.ByteString -> IO (IO (), Chan OSCBundle)
+          sendOneCycle signal = do
+            (oscBundleChan :: Chan OSCBundle) <- newChan
+            MkEnv{action, clockRef, signalRef} <- mkTestEnv $ \bundle -> do
+                writeChan oscBundleChan bundle
+            modifyMVar_ signalRef (const . return $ signal)
+            return (action cps, oscBundleChan)
+
+        it "can send an event to SuperDirt" $ id @ (IO ()) $ do
+          (action, oscBundleChan) <- sendOneCycle (embed "bd")
+          now <- Time.getCurrentTime
+          do
+            action
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (0, 1e-3)
+
+        it "can send multiple event to SuperDirt in the same cycle" $ id @ (IO ()) $ do
+          (action, oscBundleChan) <- sendOneCycle (interleave [ embed "bd", embed "sn" ])
+          now <- Time.getCurrentTime
+          do
+            action
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+
+        it "can send multiple events in multiple cycles, when invoked multiple times" $ do
+          (action, oscBundleChan) <- sendOneCycle (interleave [ fast 0.5 $ embed "bd", embed "sn" ])
+          now <- Time.getCurrentTime
+          do
+            action
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 0/2, 1e-3)
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 1/2, 1e-3)
+          do
+            action
+            do
+              OSCBundle timestamp [Right message] <- readChan oscBundleChan
+              message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "sn"])
+              (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (1/cps * 3/2, 1e-3)
+
+    describe "when running the action on loop" $ do
+      it "has minimal clock drift" $ pending

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -204,7 +204,7 @@ spec = do
             modifyMVar_ signalRef (const . return $ signal)
             return (sendEvents cps, oscBundleChan)
 
-        it "can send an event to SuperDirt" $ id @ (IO ()) $ do
+        it "can send an event to SuperDirt" $ do
           (sendEvents, oscBundleChan) <- sendOneCycle (embed "bd")
           now <- Time.getCurrentTime
           do
@@ -214,7 +214,7 @@ spec = do
               message `shouldBe` (OSC "/play2" [OSC_S "s", OSC_S "bd"])
               (timestamp `diffTimestamp` utcToTimestamp  now) `shouldBeAround` (0, 1e-3)
 
-        it "can send multiple event to SuperDirt in the same cycle" $ id @ (IO ()) $ do
+        it "can send multiple event to SuperDirt in the same cycle" $ do
           (sendEvents, oscBundleChan) <- sendOneCycle (interleave [ embed "bd", embed "sn" ])
           now <- Time.getCurrentTime
           do

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,0 +1,44 @@
+module TestUtils where
+
+import Control.Concurrent (threadDelay, forkIO)
+import Control.Monad (forever)
+import Data.Monoid ((<>))
+import Test.Hspec
+import Vivid.OSC (OSCBundle(..), OSCDatum(OSC_S), decodeOSCBundle, OSC(..), utcToTimestamp, Timestamp(..))
+
+import qualified Test.Hspec.Expectations
+import qualified Network.Socket as Network
+import qualified Network.Socket.ByteString as NetworkBS
+
+shouldBeAround :: (HasCallStack, Ord a, Num a, Show a) => a -> (a, a) -> IO ()
+shouldBeAround value (expectedValue, tolerance) =
+  let difference = abs (value - expectedValue)
+  in
+    if difference < tolerance
+    then return ()
+    else Test.Hspec.Expectations.expectationFailure
+      $ "expected "
+      <> show value
+      <> " to equal "
+      <> show expectedValue
+      <> " with a tolerance of "
+      <> show tolerance
+      <> ", when a difference of "
+      <> show difference <> " was found"
+
+-- | Serves a mock OSC server over UDP
+withMockOSCServer :: (OSCBundle -> IO ()) -> (Network.PortNumber -> IO a) -> IO a
+withMockOSCServer handleOSCBundle cont = do
+  address <- head <$> Network.getAddrInfo Nothing (Just "127.0.0.1") (Just (show Network.aNY_PORT))
+  socket <- Network.socket (Network.addrFamily address) Network.Datagram Network.defaultProtocol
+  Network.bind socket (Network.addrAddress address)
+  forkIO $ forever $ do
+    msg <- NetworkBS.recv socket 4096
+    let Right bundle = decodeOSCBundle msg -- NOTE: partial!
+    handleOSCBundle bundle
+  portNumber <- Network.socketPort socket
+  cont portNumber
+
+diffTimestamp :: Timestamp -> Timestamp -> Double
+diffTimestamp (Timestamp x) (Timestamp y) = x - y
+

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,10 +1,10 @@
 module TestUtils where
 
-import Control.Concurrent (threadDelay, forkIO)
+import Control.Concurrent (forkIO)
 import Control.Monad (forever)
 import Data.Monoid ((<>))
 import Test.Hspec
-import Vivid.OSC (OSCBundle(..), OSCDatum(OSC_S), decodeOSCBundle, OSC(..), utcToTimestamp, Timestamp(..))
+import Vivid.OSC (OSCBundle(..), decodeOSCBundle, Timestamp(..))
 
 import qualified Test.Hspec.Expectations
 import qualified Network.Socket as Network
@@ -32,7 +32,7 @@ withMockOSCServer handleOSCBundle cont = do
   address <- head <$> Network.getAddrInfo Nothing (Just "127.0.0.1") (Just (show Network.aNY_PORT))
   socket <- Network.socket (Network.addrFamily address) Network.Datagram Network.defaultProtocol
   Network.bind socket (Network.addrAddress address)
-  forkIO $ forever $ do
+  _ <- forkIO $ forever $ do
     msg <- NetworkBS.recv socket 4096
     let Right bundle = decodeOSCBundle msg -- NOTE: partial!
     handleOSCBundle bundle


### PR DESCRIPTION
## Changes:
- We no longer make use of a `Signal`'s payload's monoid instance. This might change
- The `query` field of an event is renamed `interval`

## Features:
- Talks to SuperDirt!
  - queries once per cycle, for a given `cps` rate. Currently doesn't account of clock drift.

@vivid-synth 

---

TODO;

- [x] make `sendEvents` delay agnostic.