### PR TITLE
new combinators:  interleave and nest

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,14 +18,12 @@ dependencies:
   - network
 
 library:
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   source-dirs: src
-  main: Syzygy.hs
 
 tests:
   syzygy-test:
-    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
     main: Spec.hs
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
     source-dirs: test
     dependencies:
       - syzygy

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -64,7 +64,6 @@ fast n MkSignal {signal=originalSignal} = MkSignal {signal}
       & rmap (fmap $ \ev@MkEvent { interval = (start, end) } -> ev { interval = (start / n, end / n) })
 
 -- | stack in parallel
--- TODO: deprecate
 stack :: [Signal a] -> Signal a
 stack sigs = MkSignal $ \query -> do
   MkSignal{signal} <- sigs

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -71,8 +71,8 @@ stack sigs = MkSignal $ \query -> do
 
 
 -- | filter a signal by a predicate on events
-_filt :: (Event a -> Bool) -> Signal a -> Signal a
-_filt predicate sig = MkSignal $ \query -> filter predicate $ signal sig query
+_filterSignal :: (Event a -> Bool) -> Signal a -> Signal a
+_filterSignal predicate sig = MkSignal $ \query -> filter predicate $ signal sig query
 
 -- | interleave signals within a single cycle
 interleave :: [Signal a] -> Signal a
@@ -91,7 +91,7 @@ interleave sigs = stack $ filterAndShift <$> zip sigs [0..]
     filterAndShift:: (Signal a, Rational) -> Signal a
     filterAndShift (sig, i) = sig
       & shift (i/n)
-      & _filt (makeSieve i)
+      & _filterSignal (makeSieve i)
 
 -- | interleaves scaled signals within a single cycle
 nest :: [Signal a] -> Signal a

--- a/src/Syzygy.hs
+++ b/src/Syzygy.hs
@@ -96,7 +96,10 @@ interleave sigs = stack $ filterAndShift <$> zip sigs [0..]
 
 -- | interleaves scaled signals within a single cycle
 nest :: [Signal a] -> Signal a
-nest sigs = interleave $ fast (fromIntegral $ length sigs) <$> sigs
+nest sigs = interleave $ fast n <$> sigs
+  where
+    n :: Rational
+    n = fromIntegral $ length sigs
 
 
 -- | Query a signal for once cycle at the given rate, relative to some absolute time

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -20,7 +20,6 @@ extra-source-files:
 library
   hs-source-dirs:
       src
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:
       base >= 4.7 && < 5
     , profunctors

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -118,17 +118,17 @@ spec = do
           , MkEvent ((1/2), (3/2)) ()
           ]
 
-    describe "_filt" $ do
+    describe "_filterSignal" $ do
       let
         pat :: Signal String
         pat = fast 4 $ embed "bd"
       it "should return no events when predicate is always false" $ do
         let predicate = const False
-        signal (_filt predicate pat) (0, 2) `shouldBe` mempty
+        signal (_filterSignal predicate pat) (0, 2) `shouldBe` mempty
 
       it "should return all events when predicate is always true" $ do
         let predicate = const True
-        signal (_filt predicate pat) (0, 2) `shouldBe` signal pat (0, 2)
+        signal (_filterSignal predicate pat) (0, 2) `shouldBe` signal pat (0, 2)
 
       it "should be able to use a custom predicate" $ do
         let predicate MkEvent{interval= (start, _)} =
@@ -136,7 +136,7 @@ spec = do
                 startFract = (snd $ properFraction @ Rational @ Integer start)
               in
                 startFract >= 0 && startFract < 0.5
-        signal (_filt predicate pat) (0, 2) `shouldBe` signal pat (0, 0.5) <> signal pat (1, 1.5)
+        signal (_filterSignal predicate pat) (0, 2) `shouldBe` signal pat (0, 0.5) <> signal pat (1, 1.5)
 
     describe "interleave" $ do
       let

--- a/test/SyzygySpec.hs
+++ b/test/SyzygySpec.hs
@@ -195,7 +195,7 @@ spec = do
             <> signal (shift (2/3) $ fast 3 c) (2/3, 1)
 
       describe "for multiple cycles" $ do
-        it "should play patterns, shifted in order" $ do
+        it "should play scaled patterns, shifted in order" $ do
           signal (nest [a, b]) (0, 2) `shouldMatchList` mempty
             <> signal (shift (0/2) $ fast 2 a) ((0/2),(1/2))
             <> signal (shift (1/2) $ fast 2 b) ((1/2),(2/2))


### PR DESCRIPTION
Changes the semantics of `interleave`. Before we we would simply stack shifted signals. Now we stack shifted, filtered signals.

Introduces `nest`, which is `interleave` but events are scaled by `n`. This effectively matches Tidal's string DSL.

TODO:
- [x] implement `_filterSignal`
- [x] implement `interleave` from `_filter` and `stack`
- [x] implement `nest` from `interleave` and `fast`