### PR TITLE
Live-code Mechanism + MIDI improvements

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,9 +39,9 @@ library:
   source-dirs: src
 
 executables:
-  syzygy-midi:
+  syzygy-live:
     source-dirs: src
-    main: Live.hs
+    main: main.hs
 
 tests:
   syzygy-test:

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,7 @@ library:
 executables:
   syzygy-midi:
     source-dirs: src
-    main: main.hs
+    main: Live.hs
 
 tests:
   syzygy-test:

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ dependencies:
   - alsa-core
   - alsa-seq
   - foreign-store
-  - clock
+  # - clock
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - alsa-core
   - alsa-seq
   - foreign-store
+  - clock
 
 library:
   source-dirs: src
@@ -42,12 +43,12 @@ executables:
     source-dirs: src
     main: main.hs
 
-# tests:
-#   syzygy-test:
-#     main: Spec.hs
-#     source-dirs: test
-#     dependencies:
-#       - syzygy
-#       - hspec
-#       - hspec-expectations
-#       - QuickCheck
+tests:
+  syzygy-test:
+    main: Spec.hs
+    source-dirs: test
+    dependencies:
+      - syzygy
+      - hspec
+      - hspec-expectations
+      - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -32,16 +32,22 @@ dependencies:
   - network
   - alsa-core
   - alsa-seq
+  - foreign-store
 
 library:
   source-dirs: src
 
-tests:
-  syzygy-test:
-    main: Spec.hs
-    source-dirs: test
-    dependencies:
-      - syzygy
-      - hspec
-      - hspec-expectations
-      - QuickCheck
+executables:
+  syzygy-midi:
+    source-dirs: src
+    main: main.hs
+
+# tests:
+#   syzygy-test:
+#     main: Spec.hs
+#     source-dirs: test
+#     dependencies:
+#       - syzygy
+#       - hspec
+#       - hspec-expectations
+#       - QuickCheck

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -9,7 +9,6 @@ import Syzygy.MIDI
 
 main :: IO ()
 main = do
-  print "Hello"
   MkMIDIConfig {signalRef} <- runOnce $ do
     signalRef <- newMVar mempty
     clockRef <- newMVar 0

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -3,7 +3,6 @@ module Live where
 import Control.Concurrent
 import Data.Word (Word8)
 
-
 import Syzygy.Core
 import Syzygy.Signal
 import Syzygy.MIDI
@@ -20,7 +19,6 @@ main = do
     _ <- forkIO $ runBackend backend config
     return config
   modifyMVar_ signalRef $ const . return $ sig
-  threadDelay 1000000000
 
 sig :: Signal Word8
 sig = nest $ (embed$) <$> [x + 40 | x <- [0, 12, 28, 24, 16]]

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -1,0 +1,26 @@
+module Live where
+
+import Control.Concurrent
+import Data.Word (Word8)
+
+
+import Syzygy.Core
+import Syzygy.Signal
+import Syzygy.MIDI
+
+main :: IO ()
+main = do
+  print "Hello"
+  MkMIDIConfig {signalRef} <- runOnce $ do
+    signalRef <- newMVar mempty
+    clockRef <- newMVar 0
+    bpmRef <- newMVar 120
+    let midiPortName = "VirMIDI 2-0"
+    let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, clockRef}
+    _ <- forkIO $ runBackend backend config
+    return config
+  modifyMVar_ signalRef $ const . return $ sig
+  threadDelay 1000000000
+
+sig :: Signal Word8
+sig = nest $ (embed$) <$> [x + 40 | x <- [0, 12, 28, 24, 16]]

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -27,7 +27,7 @@ _delay bpm ppb = threadDelay ((10^6 * 60) `div` bpm `div` ppb)
 runBackend :: Backend config a -> config -> IO ()
 runBackend MkBackend {toCoreConfig, makeEnv} config = do
   let MkCoreConfig { bpmRef, signalRef, clockRef } = toCoreConfig config
-  let ppb = 1 -- 24 pulses per beat
+  let ppb = 24 -- 24 pulses per beat
   MkEnv{sendEvents} <- makeEnv config
   forever $ do
     bpm <- readMVar bpmRef

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -97,6 +97,8 @@ makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midi
       _ <- MIDIEvent.drainOutput h
       return ()
   _ <- Queue.control h queue MIDIEvent.QueueStart Nothing
+  -- now <- Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
+  -- _ <- Queue.control h queue (MIDIEvent.QueueSetPosTime $ ALSARealTime.fromInteger now) Nothing
   continuation MkEnv {sendEvents}
 
 makeMIDIEnv :: MIDIConfig -> IO (Env Word8)

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -85,10 +85,8 @@ makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midi
         extractNote :: Event Word8 -> (Integer, Word8)
         extractNote MkEvent {interval=(eventStart, _), payload} = (nanosecs, payload)
           where
-            foo = floor $ (10^9 * 60) * (eventStart - clockVal) / fromIntegral bpm
-
             nanosecs :: Integer
-            nanosecs = foo
+            nanosecs = floor $ (10^9 * 60) * (eventStart - clockVal) / fromIntegral bpm
 
         notes :: [(Integer, Word8)]
         notes = extractNote <$> events
@@ -96,6 +94,7 @@ makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midi
       _ <- traverse sendNote notes
       _ <- MIDIEvent.drainOutput h
       return ()
+
   _ <- Queue.control h queue MIDIEvent.QueueStart Nothing
   -- now <- Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
   -- _ <- Queue.control h queue (MIDIEvent.QueueSetPosTime $ ALSARealTime.fromInteger now) Nothing

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -16,7 +16,6 @@ import qualified Sound.ALSA.Sequencer.Port.Info as PortInfo
 import qualified Sound.ALSA.Sequencer.Queue as Queue
 -- import qualified System.Clock as Clock
 
-
 import Syzygy.Core
 import Syzygy.Signal
 

--- a/src/Syzygy/SuperDirt.hs
+++ b/src/Syzygy/SuperDirt.hs
@@ -65,8 +65,8 @@ backend = MkBackend {toCoreConfig, makeEnv}
 
 main :: IO ()
 main = do
-  bpmRef <- newMVar 60
-  signalRef <- newMVar $ fast 4 $ nest [embed "bd", fast 2 $ embed "bd"]
+  bpmRef <-  newMVar 60
+  signalRef <- newMVar mempty
   clockRef <- newMVar 0
   let superDirtPortNumber = 57120
   let config = MkSuperDirtConfig { bpmRef, signalRef, clockRef, superDirtPortNumber }

--- a/src/Syzygy/SuperDirt.hs
+++ b/src/Syzygy/SuperDirt.hs
@@ -65,8 +65,8 @@ backend = MkBackend {toCoreConfig, makeEnv}
 
 main :: IO ()
 main = do
-  bpmRef <-  newMVar 60
-  signalRef <- newMVar mempty
+  bpmRef <- newMVar 60
+  signalRef <- newMVar $ fast 4 $ nest [embed "bd", fast 2 $ embed "bd"]
   clockRef <- newMVar 0
   let superDirtPortNumber = 57120
   let config = MkSuperDirtConfig { bpmRef, signalRef, clockRef, superDirtPortNumber }

--- a/src/main.hs
+++ b/src/main.hs
@@ -1,0 +1,3 @@
+import qualified Live
+main :: IO ()
+main = Live.main

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -31,6 +31,7 @@ library
     , network
     , alsa-core
     , alsa-seq
+    , foreign-store
   exposed-modules:
       Syzygy.Core
       Syzygy.MIDI
@@ -40,11 +41,10 @@ library
       Paths_syzygy
   default-language: Haskell2010
 
-test-suite syzygy-test
-  type: exitcode-stdio-1.0
-  main-is: Spec.hs
+executable syzygy-midi
+  main-is: main.hs
   hs-source-dirs:
-      test
+      src
   default-extensions: DeriveFunctor DuplicateRecordFields GeneralizedNewtypeDeriving NamedFieldPuns OverloadedStrings ScopedTypeVariables TypeApplications ViewPatterns MultiParamTypeClasses RankNTypes
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -fno-warn-type-defaults -fno-warn-name-shadowing
   build-depends:
@@ -56,14 +56,10 @@ test-suite syzygy-test
     , network
     , alsa-core
     , alsa-seq
-    , syzygy
-    , hspec
-    , hspec-expectations
-    , QuickCheck
+    , foreign-store
   other-modules:
-      Syzygy.CoreSpec
-      Syzygy.MIDISpec
-      Syzygy.SignalSpec
-      Syzygy.SuperDirtSpec
-      TestUtils
+      Syzygy.Core
+      Syzygy.MIDI
+      Syzygy.Signal
+      Syzygy.SuperDirt
   default-language: Haskell2010

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -32,6 +32,7 @@ library
     , alsa-core
     , alsa-seq
     , foreign-store
+    , clock
   exposed-modules:
       Syzygy.Core
       Syzygy.MIDI
@@ -57,9 +58,40 @@ executable syzygy-midi
     , alsa-core
     , alsa-seq
     , foreign-store
+    , clock
   other-modules:
       Syzygy.Core
       Syzygy.MIDI
       Syzygy.Signal
       Syzygy.SuperDirt
+  default-language: Haskell2010
+
+test-suite syzygy-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  default-extensions: DeriveFunctor DuplicateRecordFields GeneralizedNewtypeDeriving NamedFieldPuns OverloadedStrings ScopedTypeVariables TypeApplications ViewPatterns MultiParamTypeClasses RankNTypes
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -fno-warn-type-defaults -fno-warn-name-shadowing
+  build-depends:
+      base >= 4.7 && < 5
+    , profunctors
+    , vivid-osc
+    , bytestring
+    , time
+    , network
+    , alsa-core
+    , alsa-seq
+    , foreign-store
+    , clock
+    , syzygy
+    , hspec
+    , hspec-expectations
+    , QuickCheck
+  other-modules:
+      Syzygy.CoreSpec
+      Syzygy.MIDISpec
+      Syzygy.SignalSpec
+      Syzygy.SuperDirtSpec
+      TestUtils
   default-language: Haskell2010

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -34,6 +34,7 @@ library
     , foreign-store
     , clock
   exposed-modules:
+      Live
       Syzygy.Core
       Syzygy.MIDI
       Syzygy.Signal
@@ -43,7 +44,7 @@ library
   default-language: Haskell2010
 
 executable syzygy-midi
-  main-is: main.hs
+  main-is: Live.hs
   hs-source-dirs:
       src
   default-extensions: DeriveFunctor DuplicateRecordFields GeneralizedNewtypeDeriving NamedFieldPuns OverloadedStrings ScopedTypeVariables TypeApplications ViewPatterns MultiParamTypeClasses RankNTypes

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -32,7 +32,6 @@ library
     , alsa-core
     , alsa-seq
     , foreign-store
-    , clock
   exposed-modules:
       Live
       Syzygy.Core
@@ -43,8 +42,8 @@ library
       Paths_syzygy
   default-language: Haskell2010
 
-executable syzygy-midi
-  main-is: Live.hs
+executable syzygy-live
+  main-is: main.hs
   hs-source-dirs:
       src
   default-extensions: DeriveFunctor DuplicateRecordFields GeneralizedNewtypeDeriving NamedFieldPuns OverloadedStrings ScopedTypeVariables TypeApplications ViewPatterns MultiParamTypeClasses RankNTypes
@@ -59,8 +58,8 @@ executable syzygy-midi
     , alsa-core
     , alsa-seq
     , foreign-store
-    , clock
   other-modules:
+      Live
       Syzygy.Core
       Syzygy.MIDI
       Syzygy.Signal
@@ -84,7 +83,6 @@ test-suite syzygy-test
     , alsa-core
     , alsa-seq
     , foreign-store
-    , clock
     , syzygy
     , hspec
     , hspec-expectations

--- a/test/Syzygy/MIDISpec.hs
+++ b/test/Syzygy/MIDISpec.hs
@@ -78,7 +78,7 @@ spec = do
       config@MkMIDIConfig{signalRef} <- makeDefaultConfig
       modifyMVar_ signalRef (const $ return $ embed 60)
       withMockMIDIServer config $ \MkTestContext{onEvent} -> do
-        events <- sequence $ replicate 24 $ onEvent return
+        events <- sequence $ replicate 2 $ onEvent return
         let
           filteredData :: [MIDIEvent.Data]
           filteredData = do


### PR DESCRIPTION
We include a live-code mechanism by using `foreign-store` to execute setup code in `main` only once in the ghci(d) session. The rest of `main` is executed on every recompile.

```haskell
ghcid -T 'Live.main'
```

---

In addition, this PR includes a few changes to the MIDI Backend:

- got rid of midi tick events
- events now include a (relative) timestamp