### PR TITLE
MIDI note off

### DIFF
--- a/src/Live.hs
+++ b/src/Live.hs
@@ -2,22 +2,32 @@ module Live where
 
 import Control.Concurrent
 import Data.Word (Word8)
+import Data.Function ((&))
 
 import Syzygy.Core
 import Syzygy.Signal
 import Syzygy.MIDI
 
+setup :: IO MIDIConfig
+setup = do
+  signalRef <- newMVar mempty
+  clockRef <- newMVar 0
+  bpmRef <- newMVar 120
+  let midiPortName = "VirMIDI 2-0"
+  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, clockRef}
+  _ <- forkIO $ runBackend backend config
+  return config
+
 main :: IO ()
 main = do
-  MkMIDIConfig {signalRef} <- runOnce $ do
-    signalRef <- newMVar mempty
-    clockRef <- newMVar 0
-    bpmRef <- newMVar 120
-    let midiPortName = "VirMIDI 2-0"
-    let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, clockRef}
-    _ <- forkIO $ runBackend backend config
-    return config
+  MkMIDIConfig {signalRef, bpmRef} <- runOnce setup
+  modifyMVar_ bpmRef $ const . return $ 120
   modifyMVar_ signalRef $ const . return $ sig
 
 sig :: Signal Word8
-sig = nest $ (embed$) <$> [x + 40 | x <- [0, 12, 28, 24, 16]]
+sig = mconcat
+  [ fast (4/16) $ nest $ (embed$) <$> [x + 52 + y | x <- [0, 12, 24, 28, 16], y <- [0, 5, 12, -7, -12]]
+  , nest [embed 32]
+  ]
+  & fast (1/2)
+  & fmap (+(0))

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -27,7 +27,6 @@ main = do
 sig :: Signal Word8
 sig = mconcat
   [ fast (4/16) $ nest $ (embed$) <$> [x + 52 + y | x <- [0, 12, 24, 28, 16], y <- [0, 5, 12, -7, -12]]
-  , nest [embed 32]
   ]
-  & fast (1/2)
+  & fast (1/1)
   & fmap (+(0))

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -75,12 +75,6 @@ noteOff address queue delay pitch = stamp queue delay $ MIDIEvent.simple address
 makeMIDIEnv' :: MIDIConfig -> (Env Word8 -> IO ()) -> IO ()
 makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midiPortName $ \h address queue -> do
   let
-    sendEvent :: MIDIEvent.T -> IO ()
-    sendEvent event = do
-      _ <- MIDIEvent.output h event
-      return ()
-
-  let
     sendEvents :: Rational -> [Event Word8] -> IO ()
     sendEvents clockVal events = do
       bpm <- readMVar bpmRef
@@ -97,7 +91,7 @@ makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midi
         notes :: [MIDIEvent.T]
         notes =  events >>= extractMIDIEvents
 
-      _ <- traverse sendEvent notes
+      _ <- traverse (MIDIEvent.output h)notes
       _ <- MIDIEvent.drainOutput h
       return ()
 

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -46,9 +46,6 @@ connectTo expectedPortName continuation = do
           Queue.with h $ \queue -> do
             continuation h address queue
 
-makeNote :: Word8 -> MIDIEvent.Data
-makeNote pitch = MIDIEvent.NoteEv MIDIEvent.NoteOn (MIDIEvent.simpleNote (MIDIEvent.Channel 0) (MIDIEvent.Pitch pitch) (MIDIEvent.Velocity 255))
-
 data MIDIConfig = MkMIDIConfig
   { midiPortName :: String
   , bpmRef :: MVar Int
@@ -56,39 +53,51 @@ data MIDIConfig = MkMIDIConfig
   , clockRef :: MVar Rational
   }
 
-stamp :: Integer -> Queue.T -> MIDIEvent.T -> MIDIEvent.T
-stamp nanosecs queue event = event
+stamp :: Queue.T -> Integer -> MIDIEvent.T -> MIDIEvent.T
+stamp queue nanosecs event = event
   {
     MIDIEvent.queue = queue
   , MIDIEvent.time = ALSATime.consRel $ ALSATime.Real $ ALSARealTime.fromInteger nanosecs
   }
 
+makeNoteOnData :: Word8 -> MIDIEvent.Data
+makeNoteOnData pitch = MIDIEvent.NoteEv MIDIEvent.NoteOn (MIDIEvent.simpleNote (MIDIEvent.Channel 0) (MIDIEvent.Pitch pitch) (MIDIEvent.Velocity 255))
+
+makeNoteOffData :: Word8 -> MIDIEvent.Data
+makeNoteOffData pitch = MIDIEvent.NoteEv MIDIEvent.NoteOff (MIDIEvent.simpleNote (MIDIEvent.Channel 0) (MIDIEvent.Pitch pitch) (MIDIEvent.Velocity 255))
+
+noteOn :: Addr.T ->  Queue.T -> Integer -> Word8 -> MIDIEvent.T
+noteOn address queue delay pitch = stamp queue delay $ MIDIEvent.simple address (makeNoteOnData pitch)
+
+noteOff :: Addr.T ->  Queue.T -> Integer -> Word8 -> MIDIEvent.T
+noteOff address queue delay pitch = stamp queue delay $ MIDIEvent.simple address (makeNoteOffData pitch)
+
 makeMIDIEnv' :: MIDIConfig -> (Env Word8 -> IO ()) -> IO ()
 makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midiPortName $ \h address queue -> do
   let
-    sendNote :: (Integer, Word8) -> IO ()
-    sendNote (delay, pitch) = do
-      let event = stamp delay queue $ MIDIEvent.simple address (makeNote pitch)
+    sendEvent :: MIDIEvent.T -> IO ()
+    sendEvent event = do
       _ <- MIDIEvent.output h event
       return ()
 
-    _tick :: IO ()
-    _tick = void $ MIDIEvent.output h $ MIDIEvent.simple address $ MIDIEvent.QueueEv (MIDIEvent.QueueClock) Queue.direct
   let
     sendEvents :: Rational -> [Event Word8] -> IO ()
     sendEvents clockVal events = do
       bpm <- readMVar bpmRef
       let
-        extractNote :: Event Word8 -> (Integer, Word8)
-        extractNote MkEvent {interval=(eventStart, _), payload} = (nanosecs, payload)
+        extractMIDIEvents :: Event Word8 -> [MIDIEvent.T]
+        extractMIDIEvents MkEvent {interval=(eventStart, eventEnd), payload} =
+            [ noteOn address queue (getDelay eventStart) payload
+            , noteOff address queue (getDelay eventEnd) payload
+            ]
           where
-            nanosecs :: Integer
-            nanosecs = floor $ (10^9 * 60) * (eventStart - clockVal) / fromIntegral bpm
+            getDelay :: Rational -> Integer
+            getDelay val = floor $ (10^9 * 60) * (val - clockVal) / fromIntegral bpm
 
-        notes :: [(Integer, Word8)]
-        notes = extractNote <$> events
+        notes :: [MIDIEvent.T]
+        notes =  events >>= extractMIDIEvents
 
-      _ <- traverse sendNote notes
+      _ <- traverse sendEvent notes
       _ <- MIDIEvent.drainOutput h
       return ()
 

--- a/test/Syzygy/MIDISpec.hs
+++ b/test/Syzygy/MIDISpec.hs
@@ -78,7 +78,7 @@ spec = do
       config@MkMIDIConfig{signalRef} <- makeDefaultConfig
       modifyMVar_ signalRef (const $ return $ embed 60)
       withMockMIDIServer config $ \MkTestContext{onEvent} -> do
-        events <- sequence $ replicate 2 $ onEvent return
+        events <- sequence $ replicate 3 $ onEvent return
         let
           filteredData :: [MIDIEvent.Data]
           filteredData = do
@@ -87,7 +87,12 @@ spec = do
               body@(MIDIEvent.NoteEv _ _) -> return body
               _ -> fail "not note"
 
-          note :: MIDIEvent.Note
-          [MIDIEvent.NoteEv _ note] = filteredData
+          noteEv1, noteEv2 :: MIDIEvent.NoteEv
+          note1, note2 :: MIDIEvent.Note
+          [ MIDIEvent.NoteEv noteEv1 note1, MIDIEvent.NoteEv noteEv2 note2] = filteredData
 
-        getPitch note `shouldBe` 60
+        getPitch note1 `shouldBe` 60
+        noteEv1 `shouldBe` MIDIEvent.NoteOn
+
+        getPitch note2 `shouldBe` 60
+        noteEv2 `shouldBe` MIDIEvent.NoteOff


### PR DESCRIPTION
Now `NoteOff` will be triggered at the end of a MIDI event.

TODO:
- ~See if `NoteOff` event population needs to be done at the Signal level, as there may the situation where a `NoteOff` will override a `NoteOn`, even though the `NoteOn`'s onset is before the `NoteOff`'s~ Filed in a separate issue (#19)