### PR TITLE
Improved timing + Absolute MIDI Timestamps

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ dependencies:
   - alsa-core
   - alsa-seq
   - foreign-store
+  - clock
 
 library:
   source-dirs: src

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -15,11 +15,11 @@ import Syzygy.MIDI
 setup :: IO MIDIConfig
 setup = do
   signalRef <- newMVar mempty
-  clockRef <- newMVar 0
+  beatRef <- newMVar 0
   bpmRef <- newMVar 120
   let midiPortName = "UM-ONE MIDI 1"
   -- let midiPortName = "VirMIDI 2-0"
-  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, clockRef}
+  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, beatRef}
   _ <- forkIO $ runBackend backend config
   return config
 

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -26,7 +26,7 @@ setup = do
 main :: IO ()
 main = do
   MkMIDIConfig {signalRef, bpmRef} <- runOnce setup
-  modifyMVar_ bpmRef $ const . return $ 120
+  modifyMVar_ bpmRef $ const . return $ 160
   modifyMVar_ signalRef $ const . return $ sigMod mempty
 
 with :: Functor f => (f a -> a) -> f (a -> a) -> a -> a
@@ -46,23 +46,37 @@ fracture n f = foldr (flip (.)) id ([tt (1/(2^i)) f | i <- [0..n]])
 overlay :: (Signal a -> Signal a) -> (Signal a -> Signal a)
 overlay f = with mconcat [id, f]
 
+filterSig :: (a -> Bool) -> Signal a -> Signal a
+filterSig pred sig = MkSignal $ \query -> signal sig query
+  & filter (\MkEvent{payload}-> pred payload)
+
+lpf :: Word8 -> Signal Word8 -> Signal Word8
+lpf i = filterSig $ (<i)
+
+hpf :: Word8 -> Signal Word8 -> Signal Word8
+hpf i = filterSig $ (>i)
+
 sigMod :: Signal Word8 -> Signal Word8
 sigMod = let (>>) = (flip (.)) in do
-  const (embed 24)
-  with nest [ fmap (+x)| x <- [0, 12, 19, 0]]
-  tt (1/2) $ with switch [fmap (+2) , id]
-  fast 1
-  tt (1/4) $ with switch [fmap (+29), fmap (+24)]
-  overlay $ do
-    tt 4 $ with switch
-      [ fmap (+0)
-      , fmap (+24)
-      , fmap (subtract 7)
-      ]
-    tt 8 $ with switch
-      [ fmap (+0)
-      , fmap (subtract 7)
-      , fmap (subtract 24)
-      ]
-    overlay $ shift (0.5)
-  tt (1/8) $ with switch [id, (fmap (subtract 7))]
+  const (embed 0)
+  with switch [ fmap (+(x)) | x <- [0, 12, 19, 0] >>= replicate 1]
+  fast 4
+  -- with switch [id, slow 2]
+  -- slow (1.5)
+  -- tt (1/2) $ with switch [fmap (+2) , id]
+  -- tt (1/4) $ with switch [fmap (+29), fmap (+24)]
+  -- tt (1/8) $ with switch [id, (fmap (subtract 7))]
+  -- tt (1/16) $ with switch [id, (fmap (+5))]
+  tt 8 $ with switch
+    [ fmap (+0)
+    , fmap (+24)
+    -- , fmap (subtract 7)
+    ]
+  -- tt 8 $ with switch
+  --   [ fmap (+24)
+  --   , fmap (subtract 24)
+  --   ]
+  -- overlay $ do
+  --   tt 4 $ with switch [id, const (mempty)]
+  --   shift 0.25
+  -- tt 4 $ with switch [id, const (mempty)]

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -26,7 +26,7 @@ setup = do
 main :: IO ()
 main = do
   MkMIDIConfig {signalRef, bpmRef} <- runOnce setup
-  modifyMVar_ bpmRef $ const . return $ 120
+  modifyMVar_ bpmRef $ const . return $ 160
   modifyMVar_ signalRef $ const . return $ sigMod mempty
 
 with :: Functor f => (f a -> a) -> f (a -> a) -> a -> a
@@ -61,9 +61,7 @@ staccato sig = sig & (mapInterval . mapDur) (/4)
 
 sigMod :: Signal Word8 -> Signal Word8
 sigMod = let (>>) = (flip (.)) in do
-  staccato
   const (embed 60)
-  with switch [ fmap (+(x + y)) | x <- [0, 3, 7, 10, 15, 17, 22, 24, 26, 27] >>= replicate 1 | y <- cycle [0, -24, 12]]
-  fast 16
-  tt (1/2) $ with switch [id, fmap (subtract 12)]
-  tt (1/8) $ with switch [id, fmap (subtract 2)]
+  with switch [ fmap (+(x)) | x <- [-0, 3, 7, 10, 14, 15, 17, 26, 27, 10, 14, 7, 3]]
+  fast 8
+  tt (1/4)  $ with switch [fmap (subtract x) | x <- [0, 5, 2, 7]]

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -26,7 +26,7 @@ newtype Env a = MkEnv
 runBackend :: Backend config a -> config -> IO ()
 runBackend MkBackend {toCoreConfig, makeEnv} config = do
   let MkCoreConfig { bpmRef, signalRef, clockRef } = toCoreConfig config
-  let ppb = 24 -- 24 pulses per beat
+  let spb = 24 -- 24 samples per beat
   MkEnv{sendEvents} <- makeEnv config
   timeRef <-  newMVar =<< Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
   forever $ do
@@ -34,10 +34,10 @@ runBackend MkBackend {toCoreConfig, makeEnv} config = do
     sig <- readMVar signalRef
     let
       offsetClock :: Rational
-      offsetClock = 1 / fromIntegral ppb
+      offsetClock = 1 / fromIntegral spb
 
       offsetTime :: Integer
-      offsetTime = ((10^9 * 60) `div` fromIntegral bpm `div` fromIntegral ppb)
+      offsetTime = ((10^9 * 60) `div` fromIntegral bpm `div` fromIntegral spb)
 
     clockVal <- modifyMVar clockRef (\x -> return (x + offsetClock, x))
     timeVal <- modifyMVar timeRef (\x -> return (x + offsetTime, x))

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -26,7 +26,7 @@ newtype Env a = MkEnv
 runBackend :: Backend config a -> config -> IO ()
 runBackend MkBackend {toCoreConfig, makeEnv} config = do
   let MkCoreConfig { bpmRef, signalRef, clockRef } = toCoreConfig config
-  let ppb = 1 -- 24 pulses per beat
+  let ppb = 24 -- 24 pulses per beat
   MkEnv{sendEvents} <- makeEnv config
   lastTimeRef <-  newMVar =<< Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
   forever $ do

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -90,13 +90,13 @@ makeMIDIEnv' MkMIDIConfig { midiPortName, bpmRef } continuation = connectTo midi
     let
       notes :: [MIDIEvent.T]
       notes =  events >>= extractMIDIEvents
-    _ <- traverse (MIDIEvent.output h) notes
-    _ <- MIDIEvent.drainOutput h
+    traverse (MIDIEvent.output h) notes
+    MIDIEvent.drainOutput h
     return ()
   in do
-    _ <- Queue.control h queue MIDIEvent.QueueStart Nothing
+    Queue.control h queue MIDIEvent.QueueStart Nothing
     now <- Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
-    _ <- Queue.control h queue (MIDIEvent.QueueSetPosTime $ ALSARealTime.fromInteger now) Nothing
+    Queue.control h queue (MIDIEvent.QueueSetPosTime $ ALSARealTime.fromInteger now) Nothing
     continuation MkEnv {sendEvents}
 
 makeMIDIEnv :: MIDIConfig -> IO (Env Word8)

--- a/src/Syzygy/SuperDirt.hs
+++ b/src/Syzygy/SuperDirt.hs
@@ -44,8 +44,8 @@ makeSuperDirtEnv :: SuperDirtConfig -> IO (Env BS.ByteString)
 makeSuperDirtEnv MkSuperDirtConfig{superDirtPortNumber, bpmRef} = do
   superDirtSocket <- makeLocalUDPConnection superDirtPortNumber
   let
-    sendEvents :: Rational -> [ Event BS.ByteString ] -> IO ()
-    sendEvents clockVal events = do
+    sendEvents :: Rational -> Integer -> [ Event BS.ByteString ] -> IO ()
+    sendEvents clockVal _ events = do
       now <- Time.getCurrentTime
       bpm <- readMVar bpmRef
       let oscEvents = [toAbsoluteTime now clockVal bpm event | event <- events]

--- a/src/Syzygy/SuperDirt.hs
+++ b/src/Syzygy/SuperDirt.hs
@@ -22,7 +22,7 @@ data SuperDirtConfig = MkSuperDirtConfig
   { superDirtPortNumber :: Network.PortNumber
   , bpmRef :: MVar Int
   , signalRef :: MVar (Signal BS.ByteString)
-  , clockRef :: MVar Rational
+  , beatRef :: MVar Rational
   }
 
 toAbsoluteTime :: Time.UTCTime -> Rational -> Int -> Event a -> (Time.UTCTime, a)
@@ -57,8 +57,8 @@ backend :: Backend SuperDirtConfig BS.ByteString
 backend = MkBackend {toCoreConfig, makeEnv}
   where
     toCoreConfig :: SuperDirtConfig -> CoreConfig BS.ByteString
-    toCoreConfig MkSuperDirtConfig {bpmRef, signalRef, clockRef} =
-      MkCoreConfig {bpmRef, signalRef, clockRef}
+    toCoreConfig MkSuperDirtConfig {bpmRef, signalRef, beatRef} =
+      MkCoreConfig {bpmRef, signalRef, beatRef}
 
     makeEnv :: SuperDirtConfig -> IO (Env BS.ByteString)
     makeEnv = makeSuperDirtEnv
@@ -67,7 +67,7 @@ main :: IO ()
 main = do
   bpmRef <-  newMVar 60
   signalRef <- newMVar mempty
-  clockRef <- newMVar 0
+  beatRef <- newMVar 0
   let superDirtPortNumber = 57120
-  let config = MkSuperDirtConfig { bpmRef, signalRef, clockRef, superDirtPortNumber }
+  let config = MkSuperDirtConfig { bpmRef, signalRef, beatRef, superDirtPortNumber }
   runBackend backend config

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.4
+resolver: lts-9.6
 
 packages:
 - '.'

--- a/syzygy.cabal
+++ b/syzygy.cabal
@@ -31,6 +31,7 @@ library
     , alsa-core
     , alsa-seq
     , foreign-store
+    , clock
   exposed-modules:
       Live
       Syzygy.Core
@@ -56,6 +57,7 @@ executable syzygy-live
     , alsa-core
     , alsa-seq
     , foreign-store
+    , clock
   other-modules:
       Live
       Syzygy.Core
@@ -81,6 +83,7 @@ test-suite syzygy-test
     , alsa-core
     , alsa-seq
     , foreign-store
+    , clock
     , syzygy
     , hspec
     , hspec-expectations

--- a/test/Syzygy/CoreSpec.hs
+++ b/test/Syzygy/CoreSpec.hs
@@ -1,113 +1,113 @@
 module Syzygy.CoreSpec where
 
-import Test.Hspec
-import Control.Concurrent
-import qualified Data.Time as Time
+-- import Test.Hspec
+-- import Control.Concurrent
+-- import qualified Data.Time as Time
 
-import Syzygy.Core
-import Syzygy.Signal
-import TestUtils (shouldBeLessThan)
+-- import Syzygy.Core
+-- import Syzygy.Signal
+-- import TestUtils (shouldBeLessThan)
 
-makeMockBackend :: Chan (Rational, [Event String]) -> MVar () ->  Backend (CoreConfig String) String
-makeMockBackend spyChan sem = MkBackend {toCoreConfig, makeEnv}
-  where
-    toCoreConfig :: CoreConfig String -> CoreConfig String
-    toCoreConfig = id
+-- makeMockBackend :: Chan (Rational, [Event String]) -> MVar () ->  Backend (CoreConfig String) String
+-- makeMockBackend spyChan sem = MkBackend {toCoreConfig, makeEnv}
+--   where
+--     toCoreConfig :: CoreConfig String -> CoreConfig String
+--     toCoreConfig = id
 
-    sendEvents :: Rational -> [Event String] -> IO ()
-    sendEvents clockVal events = do
-      writeChan spyChan (clockVal, events)
-      takeMVar sem
+--     sendEvents :: Rational -> [Event String] -> IO ()
+--     sendEvents clockVal events = do
+--       writeChan spyChan (clockVal, events)
+--       takeMVar sem
 
-    makeEnv :: CoreConfig String -> IO (Env String)
-    makeEnv _ = return MkEnv { sendEvents }
+--     makeEnv :: CoreConfig String -> IO (Env String)
+--     makeEnv _ = return MkEnv { sendEvents }
 
-data MockContext = MkMockContext
-  { withMockSendEvent :: (Rational -> [ Event String ] -> IO ()) -> IO ()
-  , bpmRef :: MVar Int
-  , signalRef :: MVar (Signal String)
-  }
+-- data MockContext = MkMockContext
+--   { withMockSendEvent :: (Rational -> [ Event String ] -> IO ()) -> IO ()
+--   , bpmRef :: MVar Int
+--   , signalRef :: MVar (Signal String)
+--   }
 
-withMockBackend :: CoreConfig String -> (MockContext -> IO ()) -> IO ()
-withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
-  (spyChan :: Chan (Rational, [Event String])) <- newChan
-  (semaphore :: MVar ()) <- newEmptyMVar
-  let
-    mockBackend :: Backend (CoreConfig String) String
-    mockBackend = makeMockBackend spyChan semaphore
+-- withMockBackend :: CoreConfig String -> (MockContext -> IO ()) -> IO ()
+-- withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
+--   (spyChan :: Chan (Rational, [Event String])) <- newChan
+--   (semaphore :: MVar ()) <- newEmptyMVar
+--   let
+--     mockBackend :: Backend (CoreConfig String) String
+--     mockBackend = makeMockBackend spyChan semaphore
 
-    mockConfig :: CoreConfig String
-    mockConfig = MkCoreConfig{bpmRef, signalRef, clockRef}
+--     mockConfig :: CoreConfig String
+--     mockConfig = MkCoreConfig{bpmRef, signalRef, clockRef}
 
-    withMockSendEvent :: (Rational -> [ Event String] -> IO ()) -> IO ()
-    withMockSendEvent mockSendEvents = do
-      (clockVal, events) <- readChan spyChan
-      _ <- mockSendEvents clockVal events
-      putMVar semaphore ()
+--     withMockSendEvent :: (Rational -> [ Event String] -> IO ()) -> IO ()
+--     withMockSendEvent mockSendEvents = do
+--       (clockVal, events) <- readChan spyChan
+--       _ <- mockSendEvents clockVal events
+--       putMVar semaphore ()
 
-  threadId <- forkIO $ runBackend mockBackend mockConfig
-  cont MkMockContext {withMockSendEvent, bpmRef, signalRef}
-  killThread threadId
+--   threadId <- forkIO $ runBackend mockBackend mockConfig
+--   cont MkMockContext {withMockSendEvent, bpmRef, signalRef}
+--   killThread threadId
 
-makeDefaultConfig :: IO (CoreConfig String)
-makeDefaultConfig = do
-  bpmRef <- newMVar 120
-  signalRef <- newMVar $ embed "hello"
-  clockRef <- newMVar 0
-  return MkCoreConfig {bpmRef, signalRef, clockRef}
+-- makeDefaultConfig :: IO (CoreConfig String)
+-- makeDefaultConfig = do
+--   bpmRef <- newMVar 120
+--   signalRef <- newMVar $ embed "hello"
+--   clockRef <- newMVar 0
+--   return MkCoreConfig {bpmRef, signalRef, clockRef}
 
-spec :: Spec
-spec = do
-  describe "runBackend" $ do
-    describe "when invoking sendEvents" $ do
-      it "should call sendEvents with the right clockVal each frame" $ do
-        config <- makeDefaultConfig
-        withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
-          withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (0/24)
-          sequence_ $ replicate 23 $ withMockSendEvent $ \_ _ -> return ()
-          withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (24/24)
+-- spec :: Spec
+-- spec = do
+--   describe "runBackend" $ do
+--     describe "when invoking sendEvents" $ do
+--       it "should call sendEvents with the right clockVal each frame" $ do
+--         config <- makeDefaultConfig
+--         withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+--           withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (0/24)
+--           sequence_ $ replicate 23 $ withMockSendEvent $ \_ _ -> return ()
+--           withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (24/24)
 
-      it "should call sendEvents with the right events each frame" $ do
-        config <- makeDefaultConfig
-        withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
-          withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(0, 1), payload="hello"} ]
-          sequence_ $ replicate 23 $ withMockSendEvent $ \_ events -> events `shouldBe` []
-          withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(1, 1), payload="hello"} ]
+--       it "should call sendEvents with the right events each frame" $ do
+--         config <- makeDefaultConfig
+--         withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+--           withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(0, 1), payload="hello"} ]
+--           sequence_ $ replicate 23 $ withMockSendEvent $ \_ events -> events `shouldBe` []
+--           withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(1, 1), payload="hello"} ]
 
-    describe "timing" $ do
-      let
-        getDeltas :: Int -> Int -> IO [Time.NominalDiffTime]
-        getDeltas bpm numBeats = do
-          logRef <- newMVar []
-          config@MkCoreConfig{bpmRef} <- makeDefaultConfig
-          modifyMVar_ bpmRef (const $ return $ bpm)
-          withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
-            sequence_ $ replicate (numBeats * 24) $ withMockSendEvent $ \_ _ -> modifyMVar_ logRef $ \xs -> do
-              x <- Time.getCurrentTime
-              return (x:xs)
-          times <- readMVar logRef
-          let
-            delays :: [Time.NominalDiffTime]
-            delays = tail $ zipWith (flip Time.diffUTCTime) times (undefined:times)
+--     describe "timing" $ do
+--       let
+--         getDeltas :: Int -> Int -> IO [Time.NominalDiffTime]
+--         getDeltas bpm numBeats = do
+--           logRef <- newMVar []
+--           config@MkCoreConfig{bpmRef} <- makeDefaultConfig
+--           modifyMVar_ bpmRef (const $ return $ bpm)
+--           withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+--             sequence_ $ replicate (numBeats * 24) $ withMockSendEvent $ \_ _ -> modifyMVar_ logRef $ \xs -> do
+--               x <- Time.getCurrentTime
+--               return (x:xs)
+--           times <- readMVar logRef
+--           let
+--             delays :: [Time.NominalDiffTime]
+--             delays = tail $ zipWith (flip Time.diffUTCTime) times (undefined:times)
 
-            expectedDelays :: [Time.NominalDiffTime]
-            expectedDelays = repeat $ (1 * (60/fromIntegral bpm) / 24)
+--             expectedDelays :: [Time.NominalDiffTime]
+--             expectedDelays = repeat $ (1 * (60/fromIntegral bpm) / 24)
 
-            deltas :: [Time.NominalDiffTime]
-            deltas = zipWith (\x y -> abs (x - y)) delays expectedDelays
-          return deltas
+--             deltas :: [Time.NominalDiffTime]
+--             deltas = zipWith (\x y -> abs (x - y)) delays expectedDelays
+--           return deltas
 
-      it "has a net shift of less than 10% the beat duration, at 240 bpm" $ do
-        let bpm = 240
-        deltas <- getDeltas bpm 1
-        sum deltas `shouldBeLessThan` (0.1 * (60/fromIntegral bpm))
+--       it "has a net shift of less than 10% the beat duration, at 240 bpm" $ do
+--         let bpm = 240
+--         deltas <- getDeltas bpm 1
+--         sum deltas `shouldBeLessThan` (0.1 * (60/fromIntegral bpm))
 
-      it "has a net shift of less than 3% the beat duration, at 120 bpm" $ do
-        let bpm = 120
-        deltas <- getDeltas bpm 1
-        sum deltas `shouldBeLessThan` (0.03 * (60/fromIntegral bpm))
+--       it "has a net shift of less than 3% the beat duration, at 120 bpm" $ do
+--         let bpm = 120
+--         deltas <- getDeltas bpm 1
+--         sum deltas `shouldBeLessThan` (0.03 * (60/fromIntegral bpm))
 
-      it "has a net shift of less than 2% the beat duration, at 60 bpm" $ do
-        let bpm = 60
-        deltas <- getDeltas bpm 1
-        sum deltas `shouldBeLessThan` (0.02 * (60/fromIntegral bpm))
+--       it "has a net shift of less than 2% the beat duration, at 60 bpm" $ do
+--         let bpm = 60
+--         deltas <- getDeltas bpm 1
+--         sum deltas `shouldBeLessThan` (0.02 * (60/fromIntegral bpm))

--- a/test/Syzygy/CoreSpec.hs
+++ b/test/Syzygy/CoreSpec.hs
@@ -1,113 +1,114 @@
 module Syzygy.CoreSpec where
 
--- import Test.Hspec
--- import Control.Concurrent
--- import qualified Data.Time as Time
+import Test.Hspec
+import Control.Concurrent
+import qualified Data.Time as Time
 
--- import Syzygy.Core
--- import Syzygy.Signal
--- import TestUtils (shouldBeLessThan)
+import Syzygy.Core
+import Syzygy.Signal
+import TestUtils (shouldBeLessThan)
 
--- makeMockBackend :: Chan (Rational, [Event String]) -> MVar () ->  Backend (CoreConfig String) String
--- makeMockBackend spyChan sem = MkBackend {toCoreConfig, makeEnv}
---   where
---     toCoreConfig :: CoreConfig String -> CoreConfig String
---     toCoreConfig = id
+makeMockBackend :: Chan (Rational, Integer, [Event String]) -> MVar () ->  Backend (CoreConfig String) String
+makeMockBackend spyChan sem = MkBackend {toCoreConfig, makeEnv}
+  where
+    toCoreConfig :: CoreConfig String -> CoreConfig String
+    toCoreConfig = id
 
---     sendEvents :: Rational -> [Event String] -> IO ()
---     sendEvents clockVal events = do
---       writeChan spyChan (clockVal, events)
---       takeMVar sem
+    sendEvents :: Rational -> Integer -> [Event String] -> IO ()
+    sendEvents clockVal timeVal events = do
+      writeChan spyChan (clockVal, timeVal, events)
+      takeMVar sem
 
---     makeEnv :: CoreConfig String -> IO (Env String)
---     makeEnv _ = return MkEnv { sendEvents }
+    makeEnv :: CoreConfig String -> IO (Env String)
+    makeEnv _ = return MkEnv { sendEvents }
 
--- data MockContext = MkMockContext
---   { withMockSendEvent :: (Rational -> [ Event String ] -> IO ()) -> IO ()
---   , bpmRef :: MVar Int
---   , signalRef :: MVar (Signal String)
---   }
+data MockContext = MkMockContext
+  { withMockSendEvent :: (Rational -> Integer -> [ Event String ] -> IO ()) -> IO ()
+  , bpmRef :: MVar Int
+  , signalRef :: MVar (Signal String)
+  }
 
--- withMockBackend :: CoreConfig String -> (MockContext -> IO ()) -> IO ()
--- withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
---   (spyChan :: Chan (Rational, [Event String])) <- newChan
---   (semaphore :: MVar ()) <- newEmptyMVar
---   let
---     mockBackend :: Backend (CoreConfig String) String
---     mockBackend = makeMockBackend spyChan semaphore
+withMockBackend :: CoreConfig String -> (MockContext -> IO ()) -> IO ()
+withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
+  (spyChan :: Chan (Rational, Integer, [Event String])) <- newChan
+  (semaphore :: MVar ()) <- newEmptyMVar
+  let
+    mockBackend :: Backend (CoreConfig String) String
+    mockBackend = makeMockBackend spyChan semaphore
 
---     mockConfig :: CoreConfig String
---     mockConfig = MkCoreConfig{bpmRef, signalRef, clockRef}
+    mockConfig :: CoreConfig String
+    mockConfig = MkCoreConfig{bpmRef, signalRef, clockRef}
 
---     withMockSendEvent :: (Rational -> [ Event String] -> IO ()) -> IO ()
---     withMockSendEvent mockSendEvents = do
---       (clockVal, events) <- readChan spyChan
---       _ <- mockSendEvents clockVal events
---       putMVar semaphore ()
+    withMockSendEvent :: (Rational -> Integer -> [ Event String] -> IO ()) -> IO ()
+    withMockSendEvent mockSendEvents = do
+      (clockVal, timeVal, events) <- readChan spyChan
+      _ <- mockSendEvents clockVal timeVal events
+      putMVar semaphore ()
 
---   threadId <- forkIO $ runBackend mockBackend mockConfig
---   cont MkMockContext {withMockSendEvent, bpmRef, signalRef}
---   killThread threadId
+  threadId <- forkIO $ runBackend mockBackend mockConfig
+  cont MkMockContext {withMockSendEvent, bpmRef, signalRef}
+  killThread threadId
 
--- makeDefaultConfig :: IO (CoreConfig String)
--- makeDefaultConfig = do
---   bpmRef <- newMVar 120
---   signalRef <- newMVar $ embed "hello"
---   clockRef <- newMVar 0
---   return MkCoreConfig {bpmRef, signalRef, clockRef}
+makeDefaultConfig :: IO (CoreConfig String)
+makeDefaultConfig = do
+  bpmRef <- newMVar 120
+  signalRef <- newMVar $ embed "hello"
+  clockRef <- newMVar 0
+  return MkCoreConfig {bpmRef, signalRef, clockRef}
 
--- spec :: Spec
--- spec = do
---   describe "runBackend" $ do
---     describe "when invoking sendEvents" $ do
---       it "should call sendEvents with the right clockVal each frame" $ do
---         config <- makeDefaultConfig
---         withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
---           withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (0/24)
---           sequence_ $ replicate 23 $ withMockSendEvent $ \_ _ -> return ()
---           withMockSendEvent $ \clockVal _ -> clockVal `shouldBe` (24/24)
+spec :: Spec
+spec = do
+  describe "runBackend" $ do
+    describe "when invoking sendEvents" $ do
+      it "should call sendEvents with the right clockVal each frame" $ do
+        config <- makeDefaultConfig
+        withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+          withMockSendEvent $ \clockVal _ _ -> clockVal `shouldBe` (0/24)
+          sequence_ $ replicate 23 $ withMockSendEvent $ \_ _ _ -> return ()
+          withMockSendEvent $ \clockVal _ _ -> clockVal `shouldBe` (24/24)
 
---       it "should call sendEvents with the right events each frame" $ do
---         config <- makeDefaultConfig
---         withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
---           withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(0, 1), payload="hello"} ]
---           sequence_ $ replicate 23 $ withMockSendEvent $ \_ events -> events `shouldBe` []
---           withMockSendEvent $ \_ events -> events `shouldBe` [ MkEvent {interval=(1, 1), payload="hello"} ]
+      it "should call sendEvents with the right events each frame" $ do
+        config <- makeDefaultConfig
+        withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+          withMockSendEvent $ \_ _ events -> events `shouldBe` [ MkEvent {interval=(0, 1), payload="hello"} ]
+          sequence_ $ replicate 23 $ withMockSendEvent $ \_ _ events -> events `shouldBe` []
+          withMockSendEvent $ \_ _ events -> events `shouldBe` [ MkEvent {interval=(1, 1), payload="hello"} ]
 
---     describe "timing" $ do
---       let
---         getDeltas :: Int -> Int -> IO [Time.NominalDiffTime]
---         getDeltas bpm numBeats = do
---           logRef <- newMVar []
---           config@MkCoreConfig{bpmRef} <- makeDefaultConfig
---           modifyMVar_ bpmRef (const $ return $ bpm)
---           withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
---             sequence_ $ replicate (numBeats * 24) $ withMockSendEvent $ \_ _ -> modifyMVar_ logRef $ \xs -> do
---               x <- Time.getCurrentTime
---               return (x:xs)
---           times <- readMVar logRef
---           let
---             delays :: [Time.NominalDiffTime]
---             delays = tail $ zipWith (flip Time.diffUTCTime) times (undefined:times)
+    describe "timing" $ do
+      let
+        getDeltas :: Int -> Int -> IO [Time.NominalDiffTime]
+        getDeltas bpm numBeats = do
+          logRef <- newMVar []
+          config@MkCoreConfig{bpmRef} <- makeDefaultConfig
+          modifyMVar_ bpmRef (const $ return $ bpm)
+          withMockBackend config $ \MkMockContext {withMockSendEvent} -> do
+            sequence_ $ replicate (numBeats * 24) $ withMockSendEvent $ \_ _ _ -> modifyMVar_ logRef $ \xs -> do
+              x <- Time.getCurrentTime
+              return (x:xs)
+          times <- readMVar logRef
+          let
+            delays :: [Time.NominalDiffTime]
+            delays = tail $ zipWith (flip Time.diffUTCTime) times (undefined:times)
 
---             expectedDelays :: [Time.NominalDiffTime]
---             expectedDelays = repeat $ (1 * (60/fromIntegral bpm) / 24)
+            expectedDelays :: [Time.NominalDiffTime]
+            expectedDelays = repeat $ (1 * (60/fromIntegral bpm) / 24)
 
---             deltas :: [Time.NominalDiffTime]
---             deltas = zipWith (\x y -> abs (x - y)) delays expectedDelays
---           return deltas
+            deltas :: [Time.NominalDiffTime]
+            deltas = zipWith (\x y -> abs (x - y)) delays expectedDelays
+          return deltas
 
---       it "has a net shift of less than 10% the beat duration, at 240 bpm" $ do
---         let bpm = 240
---         deltas <- getDeltas bpm 1
---         sum deltas `shouldBeLessThan` (0.1 * (60/fromIntegral bpm))
+      describe "over 24 samples" $ do
+        it "has a net shift of less than 10ms, at 240 bpm" $ do
+          let bpm = 240
+          deltas <- getDeltas bpm 1
+          sum deltas `shouldBeLessThan` 0.010
 
---       it "has a net shift of less than 3% the beat duration, at 120 bpm" $ do
---         let bpm = 120
---         deltas <- getDeltas bpm 1
---         sum deltas `shouldBeLessThan` (0.03 * (60/fromIntegral bpm))
+        it "has a net shift of less than 15ms, at 120 bpm" $ do
+          let bpm = 120
+          deltas <- getDeltas bpm 1
+          sum deltas `shouldBeLessThan` 0.015
 
---       it "has a net shift of less than 2% the beat duration, at 60 bpm" $ do
---         let bpm = 60
---         deltas <- getDeltas bpm 1
---         sum deltas `shouldBeLessThan` (0.02 * (60/fromIntegral bpm))
+        it "has a net shift of less than 15ms at 60bpm" $ do
+          let bpm = 60
+          deltas <- getDeltas bpm 1
+          sum deltas `shouldBeLessThan` 0.015

--- a/test/Syzygy/CoreSpec.hs
+++ b/test/Syzygy/CoreSpec.hs
@@ -32,7 +32,7 @@ data MockContext = MkMockContext
   }
 
 withMockBackend :: CoreConfig String -> (MockContext -> IO ()) -> IO ()
-withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
+withMockBackend MkCoreConfig {bpmRef, signalRef, beatRef} cont = do
   (spyChan :: Chan (Rational, Integer, [Event String])) <- newChan
   (semaphore :: MVar ()) <- newEmptyMVar
   let
@@ -40,7 +40,7 @@ withMockBackend MkCoreConfig {bpmRef, signalRef, clockRef} cont = do
     mockBackend = makeMockBackend spyChan semaphore
   let
     mockConfig :: CoreConfig String
-    mockConfig = MkCoreConfig{bpmRef, signalRef, clockRef}
+    mockConfig = MkCoreConfig{bpmRef, signalRef, beatRef}
   let
     withMockSendEvent :: (Rational -> Integer -> [ Event String] -> IO ()) -> IO ()
     withMockSendEvent mockSendEvents = do
@@ -55,8 +55,8 @@ makeDefaultConfig :: IO (CoreConfig String)
 makeDefaultConfig = do
   bpmRef <- newMVar 120
   signalRef <- newMVar $ embed "hello"
-  clockRef <- newMVar 0
-  return MkCoreConfig {bpmRef, signalRef, clockRef}
+  beatRef <- newMVar 0
+  return MkCoreConfig {bpmRef, signalRef, beatRef}
 
 spec :: Spec
 spec = do

--- a/test/Syzygy/CoreSpec.hs
+++ b/test/Syzygy/CoreSpec.hs
@@ -78,9 +78,6 @@ spec = do
 
     describe "timing" $ do
       let
-        spb :: Int
-        spb = 24
-      let
         getTimes :: Int -> Int -> IO [Integer]
         getTimes bpm numBeats = do
           logRef <- newMVar []
@@ -131,23 +128,23 @@ spec = do
             delays = tail $ zipWith (-) (undefined:times) times
           let
             expectedDelays :: [Integer]
-            expectedDelays = repeat $ 10^9 * 60 `div` fromIntegral bpm `div` fromIntegral spb
+            expectedDelays = repeat $ 10^9 * 60 `div` fromIntegral bpm `div` fromIntegral _samplesPerBeat
           let
             deltas :: [Double]
             deltas = zipWith (\x y -> (/(10^9)) $ fromIntegral $ abs (x - y)) delays expectedDelays
-          return $ mean deltas * fromIntegral spb
+          return $ mean deltas * fromIntegral _samplesPerBeat
 
         in void $ ($[1, 2, 4]) $ traverse $ \numBeats -> do
           describe ("over " <> show numBeats <> " beat(s)") $ do
             it "is less than 15ms/beat at 240 bpm" $ do
               let bpm = 240
               jitter <- calculateJitter bpm numBeats
-              jitter ` shouldBeLessThan` 0.015
+              jitter `shouldBeLessThan` 0.015
 
             it "is less than 15ms/beat at 120 bpm" $ do
               let bpm = 120
               jitter <- calculateJitter bpm numBeats
-              jitter ` shouldBeLessThan` 0.015
+              jitter `shouldBeLessThan` 0.015
 
             it "is less than 15ms/beat at 60bpm" $ do
               let bpm = 60

--- a/test/Syzygy/MIDISpec.hs
+++ b/test/Syzygy/MIDISpec.hs
@@ -32,7 +32,6 @@ listen clientName portName onReady eventHandler = SndSeq.withDefault SndSeq.Bloc
       event <- MIDIEvent.input h
       eventHandler event
 
-
 withMockMIDIServer :: MIDIConfig -> (TestContext -> IO a) -> IO a
 withMockMIDIServer config continuation = do
   (isReadySem :: MVar ()) <- newEmptyMVar

--- a/test/Syzygy/MIDISpec.hs
+++ b/test/Syzygy/MIDISpec.hs
@@ -1,28 +1,27 @@
+{-# LANGUAGE ViewPatterns #-}
 module Syzygy.MIDISpec where
 
 import Control.Concurrent
 import Control.Monad
 import Data.Word (Word8)
+import Data.Function
 import qualified Sound.ALSA.Sequencer as SndSeq
 import qualified Sound.ALSA.Sequencer.Client as Client
 import qualified Sound.ALSA.Sequencer.Event as MIDIEvent
 import qualified Sound.ALSA.Sequencer.Port as Port
+import qualified Sound.ALSA.Sequencer.Time as MIDITime
+import qualified Sound.ALSA.Sequencer.RealTime as MIDIRealTime
 import Test.Hspec
 
 import Syzygy.Core
 import Syzygy.MIDI
 import Syzygy.Signal
+import TestUtils (shouldBeLessThan, mean, doUntil)
 
-data TestContext = MkTestContext {onEvent :: forall a. (MIDIEvent.T -> IO a) -> IO a}
-
-makeDefaultConfig :: IO MIDIConfig
-makeDefaultConfig = do
-  signalRef <- newMVar mempty
-  beatRef <- newMVar 0
-  bpmRef <- newMVar 60
-  let midiPortName = "Syzygy test port"
-  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, beatRef}
-  return config
+data TestContext = MkTestContext
+  { onEvent :: forall a. (MIDIEvent.T -> IO a) -> IO a
+  , getNoteEvent :: IO MIDIEvent.T
+  }
 
 listen :: String -> String -> IO () -> (MIDIEvent.T -> IO ()) -> IO ()
 listen clientName portName onReady eventHandler = SndSeq.withDefault SndSeq.Block $ \(h :: SndSeq.T SndSeq.InputMode) -> do
@@ -34,7 +33,7 @@ listen clientName portName onReady eventHandler = SndSeq.withDefault SndSeq.Bloc
       eventHandler event
 
 
-withMockMIDIServer :: MIDIConfig -> (TestContext -> IO ()) -> IO ()
+withMockMIDIServer :: MIDIConfig -> (TestContext -> IO a) -> IO a
 withMockMIDIServer config continuation = do
   (isReadySem :: MVar ()) <- newEmptyMVar
   (midiEventRef :: MVar MIDIEvent.T) <- newEmptyMVar
@@ -63,36 +62,75 @@ withMockMIDIServer config continuation = do
       event <- takeMVar midiEventRef
       handleEvent event
 
-  continuation MkTestContext{onEvent}
+    getNoteEvent :: IO MIDIEvent.T
+    getNoteEvent = doUntil isNoteEvent (onEvent return)
+
+  result <- continuation MkTestContext{onEvent, getNoteEvent}
 
   killThread listenerThread
   killThread clientThread
+  return result
 
-getPitch :: MIDIEvent.Note -> Word8
-getPitch note = MIDIEvent.unPitch (MIDIEvent.noteNote note)
+getPitch :: MIDIEvent.T -> Word8
+getPitch (MIDIEvent.body -> MIDIEvent.NoteEv _ note) = MIDIEvent.unPitch (MIDIEvent.noteNote note)
+getPitch (MIDIEvent.body -> _ ) = error "not a note"
+
+getNoteEvTag :: MIDIEvent.T -> MIDIEvent.NoteEv
+getNoteEvTag (MIDIEvent.body -> MIDIEvent.NoteEv noteEv _) = noteEv
+getNoteEvTag (MIDIEvent.body -> _ ) = error "not a note"
+
+getNoteTime :: MIDIEvent.T -> Integer
+getNoteTime MIDIEvent.Cons{time = MIDITime.Cons MIDITime.Absolute (MIDITime.Real time)} = MIDIRealTime.toInteger time
+getNoteTime _ = error "not absolute time"
+
+isNoteEvent :: MIDIEvent.T -> Bool
+isNoteEvent event = case MIDIEvent.body event of
+  MIDIEvent.NoteEv _ _ -> True
+  _ -> False
+
+makeDefaultConfig :: IO MIDIConfig
+makeDefaultConfig = do
+  signalRef <- newMVar $ switch [embed 100, mempty, embed 200, mempty] & fast 2
+  beatRef <- newMVar 0
+  bpmRef <- newMVar 240
+  let midiPortName = "Syzygy test port"
+  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, beatRef}
+  return config
 
 spec :: Spec
 spec = do
-  describe "MIDI out" $ do
-    it "can send MIDI signals" $ do
-      config@MkMIDIConfig{signalRef} <- makeDefaultConfig
-      modifyMVar_ signalRef (const $ return $ embed 60)
-      withMockMIDIServer config $ \MkTestContext{onEvent} -> do
-        events <- sequence $ replicate 3 $ onEvent return
+  describe "MIDI Backend" $ do
+    it "sends MIDI events with the right notes" $ do
+      config <- makeDefaultConfig
+      withMockMIDIServer config $ \MkTestContext{getNoteEvent} -> do
+        event <- getNoteEvent
+        getPitch event `shouldBe` 100
+        getNoteEvTag event `shouldBe` MIDIEvent.NoteOn
+
+        event <- getNoteEvent
+        getPitch event `shouldBe` 100
+        getNoteEvTag event `shouldBe` MIDIEvent.NoteOff
+
+        event <- getNoteEvent
+        getPitch event `shouldBe` 200
+        getNoteEvTag event `shouldBe` MIDIEvent.NoteOn
+
+        event <- getNoteEvent
+        getPitch event `shouldBe` 200
+        getNoteEvTag event `shouldBe` MIDIEvent.NoteOff
+
+    it "sends MIDI events at the right tempo, with jitter of less than 10ns" $ do
+      config <- makeDefaultConfig
+      withMockMIDIServer config $ \MkTestContext{getNoteEvent} -> do
+        timeDifferences <- sequence [getNoteEvent | _ <- [1..10]]
+          & (fmap . fmap) getNoteTime
+          & fmap (\times -> zipWith (-) (tail times) times)
         let
-          filteredData :: [MIDIEvent.Data]
-          filteredData = do
-            event <- events
-            case MIDIEvent.body event of
-              body@(MIDIEvent.NoteEv _ _) -> return body
-              _ -> fail "not note"
-
-          noteEv1, noteEv2 :: MIDIEvent.NoteEv
-          note1, note2 :: MIDIEvent.Note
-          [ MIDIEvent.NoteEv noteEv1 note1, MIDIEvent.NoteEv noteEv2 note2] = filteredData
-
-        getPitch note1 `shouldBe` 60
-        noteEv1 `shouldBe` MIDIEvent.NoteOn
-
-        getPitch note2 `shouldBe` 60
-        noteEv2 `shouldBe` MIDIEvent.NoteOff
+          expectedTimeDifference :: Integer
+          expectedTimeDifference = (10^9) `div` (240 `div` 60) `div` 2
+        let
+          error :: [Double]
+          error = timeDifferences
+              & fmap (\delta -> abs (expectedTimeDifference - delta))
+              & fmap fromInteger
+        mean error `shouldBeLessThan` 10

--- a/test/Syzygy/MIDISpec.hs
+++ b/test/Syzygy/MIDISpec.hs
@@ -18,10 +18,10 @@ data TestContext = MkTestContext {onEvent :: forall a. (MIDIEvent.T -> IO a) -> 
 makeDefaultConfig :: IO MIDIConfig
 makeDefaultConfig = do
   signalRef <- newMVar mempty
-  clockRef <- newMVar 0
+  beatRef <- newMVar 0
   bpmRef <- newMVar 60
   let midiPortName = "Syzygy test port"
-  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, clockRef}
+  let config = MkMIDIConfig { bpmRef, midiPortName, signalRef, beatRef}
   return config
 
 listen :: String -> String -> IO () -> (MIDIEvent.T -> IO ()) -> IO ()

--- a/test/Syzygy/SuperDirtSpec.hs
+++ b/test/Syzygy/SuperDirtSpec.hs
@@ -38,8 +38,8 @@ withMockSuperDirt defaultSignal bpm continuation = do
   withMockOSCServer (putMVar bundleChan) $ \superDirtPortNumber -> do
     bpmRef <- newMVar bpm
     signalRef <- newMVar defaultSignal
-    clockRef <- newMVar 0
-    let config = MkSuperDirtConfig{superDirtPortNumber, bpmRef, signalRef, clockRef}
+    beatRef <- newMVar 0
+    let config = MkSuperDirtConfig{superDirtPortNumber, bpmRef, signalRef, beatRef}
     clientThread <- forkIO $ runBackend backend config
     let receiveOSCBundle bundleHandler = do
           bundleVal <- takeMVar bundleChan

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -14,3 +14,7 @@ shouldBeLessThan x y =
     <> show x
     <> " to be less than "
     <> show y
+
+
+mean :: Fractional a => [a] -> a
+mean xs = sum xs / (fromIntegral $ length xs)

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -15,6 +15,12 @@ shouldBeLessThan x y =
     <> " to be less than "
     <> show y
 
-
 mean :: Fractional a => [a] -> a
 mean xs = sum xs / (fromIntegral $ length xs)
+
+doUntil :: (a -> Bool) -> IO a -> IO a
+doUntil pred action = do
+  result <- action
+  if pred result
+  then return result
+  else doUntil pred action


### PR DESCRIPTION
Now we do a first order improvement regarding event timing by accounting for the time of `sendEvent`, which gives us now a constant clock skew, instead of linear WRT time.

Instead of waiting a fixed amount each time, we wait *the time remaining until the next expected sample time.*

---

We also implement absolute timestamps for the MIDI backend

---

TODO:
- [x] Investigate `System.Clock` vs `Data.Time`
- [x] MIDI timing tests