### PR TITLE
sendEvents refactor

### DIFF
--- a/src/Live.hs
+++ b/src/Live.hs
@@ -27,7 +27,9 @@ main :: IO ()
 main = do
   MkMIDIConfig {signalRef, bpmRef} <- runOnce setup
   modifyMVar_ bpmRef $ const . return $ 160
-  modifyMVar_ signalRef $ const . return $ sigMod mempty
+  modifyMVar_ signalRef $ const . return $ mempty
+    & sigMod
+    & fmap makeNoteOnData
 
 with :: Functor f => (f a -> a) -> f (a -> a) -> a -> a
 with cat mods sig = cat $ ($sig) <$> mods

--- a/src/Live.hs
+++ b/src/Live.hs
@@ -74,6 +74,6 @@ staccato sig = sig & (mapInterval . mapDur) (/4)
 sigMod :: Signal Word8 -> Signal Word8
 sigMod = let (>>) = (flip (.)) in do
   const (embed 60)
-  with switch [ fmap (+(x)) | x <- [-0, 3, 7, 10, 14, 15, 17, 26, 27, 10, 14, 7, 3]]
-  fast 8
-  tt (1/4)  $ with switch [fmap (subtract x) | x <- [0, 5, 2, 7]]
+  with switch [ fmap (+(x)) | x <- [-0, 4, 7, 11, 16, 18, 19, 21, 23]]
+  fast 6
+  tt 2 $ with switch [ fmap (+(x)) | x <- [0, 0, 0, 0, 0,0, 12]]

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -30,7 +30,7 @@ runBackend :: forall a config. Backend config a -> config -> IO ()
 runBackend MkBackend {toCoreConfig, makeEnv} config = do
   let MkCoreConfig {bpmRef, signalRef, beatRef} = toCoreConfig config
   MkEnv{sendEvents} <- makeEnv config
-  clockRef <-  newMVar =<< Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
+  clockRef <- newMVar =<< Clock.toNanoSecs <$> Clock.getTime Clock.Realtime
   forever $ do
     bpm <- readMVar bpmRef
     sig <- readMVar signalRef

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -44,7 +44,7 @@ runBackend MkBackend {toCoreConfig, makeEnv} config = do
     clock <- modifyMVar clockRef (\clock -> return (clock + clockOffset, clock))
     let
       timestampedEvents :: [(Integer, a)]
-      timestampedEvents = signal (pruneSignal sig) (beat, beatOffset)
+      timestampedEvents = signal sig (beat, beatOffset)
           & fmap (makeTimestamp bpm beat clock)
     sendEvents timestampedEvents
     waitTil (clock + clockOffset)

--- a/src/Syzygy/Core.hs
+++ b/src/Syzygy/Core.hs
@@ -50,15 +50,10 @@ runBackend MkBackend {toCoreConfig, makeEnv} config = do
     waitTil (clock + clockOffset)
 
 makeTimestamp :: Int -> Rational -> Integer -> Event a -> (Integer, a)
-makeTimestamp bpm beatStart clock MkEvent{interval=(eventStart, _), payload} =
-  let
+makeTimestamp bpm beatStart clock MkEvent{interval=(eventStart, _), payload} = (clock + offset, payload)
+  where
     offset :: Integer
     offset = floor $ (10^9 * 60) * (eventStart - beatStart) / fromIntegral bpm
-
-    time :: Integer
-    time = clock + offset
-  in
-    (time, payload)
 
 -- | waits until t nanoseconds since UNIX epoch
 waitTil :: Integer -> IO ()

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -50,14 +50,13 @@ connectTo expectedPortName continuation = do
 data MIDIConfig = MkMIDIConfig
   { midiPortName :: String
   , bpmRef :: MVar Int
-  , signalRef :: MVar (Signal Word8)
+  , signalRef :: MVar (Signal MIDIEvent.Data)
   , beatRef :: MVar Rational
   }
 
-stamp :: Queue.T -> Integer -> MIDIEvent.T -> MIDIEvent.T
-stamp queue nanosecs event = event
-  {
-    MIDIEvent.queue = queue
+stamp :: Addr.T -> Queue.T -> Integer -> MIDIEvent.Data -> MIDIEvent.T
+stamp address queue nanosecs body = (MIDIEvent.simple address body)
+  { MIDIEvent.queue = queue
   , MIDIEvent.time = ALSATime.consAbs $ ALSATime.Real $ ALSARealTime.fromInteger nanosecs
   }
 
@@ -67,21 +66,13 @@ makeNoteOnData pitch = MIDIEvent.NoteEv MIDIEvent.NoteOn (MIDIEvent.simpleNote (
 makeNoteOffData :: Word8 -> MIDIEvent.Data
 makeNoteOffData pitch = MIDIEvent.NoteEv MIDIEvent.NoteOff (MIDIEvent.simpleNote (MIDIEvent.Channel 0) (MIDIEvent.Pitch pitch) (MIDIEvent.Velocity 0))
 
-noteOn :: Addr.T ->  Queue.T -> Integer -> Word8 -> MIDIEvent.T
-noteOn address queue delay pitch = stamp queue delay $ MIDIEvent.simple address (makeNoteOnData pitch)
-
-noteOff :: Addr.T ->  Queue.T -> Integer -> Word8 -> MIDIEvent.T
-noteOff address queue delay pitch = stamp queue delay $ MIDIEvent.simple address (makeNoteOffData pitch)
-
-makeMIDIEnv' :: MIDIConfig -> (Env Word8 -> IO ()) -> IO ()
+makeMIDIEnv' :: MIDIConfig -> (Env MIDIEvent.Data -> IO ()) -> IO ()
 makeMIDIEnv' MkMIDIConfig{midiPortName} continuation = connectTo midiPortName $ \h address queue -> let
-  sendEvents :: [(Integer, Word8)] -> IO ()
+  sendEvents :: [(Integer, MIDIEvent.Data)] -> IO ()
   sendEvents events = do
     let
-      extractMIDIEvents :: (Integer, Word8) -> MIDIEvent.T
-      extractMIDIEvents (time, payload) = noteOn address queue time payload
-          -- , noteOff address queue (beatToClock (eventStart + dur)) payload
-          -- ]
+      extractMIDIEvents :: (Integer, MIDIEvent.Data) -> MIDIEvent.T
+      extractMIDIEvents (time, payload) = stamp address queue time payload
     let
       notes :: [MIDIEvent.T]
       notes =  extractMIDIEvents <$> events
@@ -94,9 +85,9 @@ makeMIDIEnv' MkMIDIConfig{midiPortName} continuation = connectTo midiPortName $ 
     Queue.control h queue (MIDIEvent.QueueSetPosTime $ ALSARealTime.fromInteger now) Nothing
     continuation MkEnv {sendEvents}
 
-makeMIDIEnv :: MIDIConfig -> IO (Env Word8)
+makeMIDIEnv :: MIDIConfig -> IO (Env MIDIEvent.Data)
 makeMIDIEnv config = do
-  (envRef :: MVar (Maybe (Env Word8))) <- newEmptyMVar
+  (envRef :: MVar (Maybe (Env MIDIEvent.Data))) <- newEmptyMVar
   void $ forkIO $ do
     makeMIDIEnv' config $ \env -> do
       putMVar envRef $ Just env
@@ -107,12 +98,12 @@ makeMIDIEnv config = do
     Just env -> return env
     Nothing -> error "Device not found"
 
-backend :: Backend MIDIConfig Word8
+backend :: Backend MIDIConfig MIDIEvent.Data
 backend = MkBackend {toCoreConfig, makeEnv}
   where
-    toCoreConfig :: MIDIConfig -> CoreConfig Word8
+    toCoreConfig :: MIDIConfig -> CoreConfig MIDIEvent.Data
     toCoreConfig MkMIDIConfig{bpmRef, signalRef, beatRef} =
       MkCoreConfig{bpmRef, signalRef, beatRef}
 
-    makeEnv :: MIDIConfig -> IO (Env Word8)
+    makeEnv :: MIDIConfig -> IO (Env MIDIEvent.Data)
     makeEnv = makeMIDIEnv

--- a/src/Syzygy/MIDI.hs
+++ b/src/Syzygy/MIDI.hs
@@ -71,11 +71,11 @@ makeMIDIEnv' MkMIDIConfig{midiPortName} continuation = connectTo midiPortName $ 
   sendEvents :: [(Integer, MIDIEvent.Data)] -> IO ()
   sendEvents events = do
     let
-      extractMIDIEvents :: (Integer, MIDIEvent.Data) -> MIDIEvent.T
-      extractMIDIEvents (time, payload) = stamp address queue time payload
+      stampEvent :: (Integer, MIDIEvent.Data) -> MIDIEvent.T
+      stampEvent (time, payload) = stamp address queue time payload
     let
       notes :: [MIDIEvent.T]
-      notes =  extractMIDIEvents <$> events
+      notes =  stampEvent <$> events
     traverse (MIDIEvent.output h) notes
     MIDIEvent.drainOutput h
     return ()

--- a/src/Syzygy/OSC.hs
+++ b/src/Syzygy/OSC.hs
@@ -60,7 +60,7 @@ backend = MkBackend {toCoreConfig, makeEnv}
 
 main :: IO ()
 main = do
-  bpmRef <-  newMVar 240
+  bpmRef <-  newMVar 120
   signalRef <- newMVar $ fast 16 $ embed [OSC.OSC "/play2" [OSC.OSC_S "s", OSC.OSC_S "bd"]]
   beatRef <- newMVar 0
   let portNumber = 57120


### PR DESCRIPTION
Backends should only be responsible for 1) setup, and 2) serializing and sending events. In this PR we shift the responsibility of calculting absolute timestamps WRT our bpm and events to `Core`.